### PR TITLE
feat: crystallize docs

### DIFF
--- a/spec/docs_spec.cr
+++ b/spec/docs_spec.cr
@@ -1,0 +1,18 @@
+require "./spec_helper"
+
+describe "Docs conversion" do
+  it "converted the docs to crystal" do
+    expected_results = [
+      "# getter: `Test::Subject#out_param`",
+      "# setter: `Test::Subject#str_list=`",
+      "# is: `Test::Subject#is_bool?`",
+      "# initializer: `Test::Subject.new`",
+      "# WARNING: **⚠️ The following code is in c ⚠️**",
+    ]
+    test_subject = File.read("./src/auto/test-1.0/subject.cr")
+
+    expected_results.each do |doc|
+      test_subject.should contain(doc)
+    end
+  end
+end

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -51,6 +51,26 @@ typedef struct _TestStruct {
  * TestSubject:
  *
  * Main class used to test all sort of things directly related or not to GObject.
+ *
+ * Example docs for testing:
+ *
+ * getter: [method@Test.Subject.get_out_param]
+ *
+ * setter: [method@Test.Subject.set_str_list]
+ *
+ * is: [method@Test.Subject.is_bool]
+ *
+ * initializer: [ctor@Test.Subject.new]
+ *
+ * code block:
+ * ```c
+ * #include <stdio.h>
+ * int main() {
+ *    printf("Hello, World!");
+ *    return 0;
+ * }
+ * ```
+ *
  */
 #define TEST_TYPE_SUBJECT test_subject_get_type()
 G_DECLARE_DERIVABLE_TYPE(TestSubject, test_subject, TEST, SUBJECT, GObject)


### PR DESCRIPTION
This PR attempts to "crystallize" the extracted docs so they follow [the "spec"](https://crystal-lang.org/reference/1.3/syntax_and_semantics/documenting_code.html#markup).

So far:

- It adds a warning above codeblocks that contain code in a language (code blocks with no language set don't have it) (*Warning message copied from gtk-rs*)

![Screenshot of docs showing WARNING ⚠️ The following code is in c ⚠️](https://user-images.githubusercontent.com/18014039/156681646-4e0cb606-b05a-4036-8aea-82d892ed4d42.png)

- Tries to link methods, classes etc (eg. `[method@Gtk.TextBuffer.set_enable_undo]` => `Gtk::TextBuffer#enable_undo=` (link))

![Screenshot of docs showing Gtk::TextBuffer#enable_undo= as link](https://user-images.githubusercontent.com/18014039/156681924-1d09d8eb-a922-4c73-9d62-9c713b686e31.png)

Draft for now as it probably needs further testing, optimization, specs & catching edge cases.

