### PR TITLE
Add `execute_callback` / Fix #8

### DIFF
--- a/ecr/lib.ecr
+++ b/ecr/lib.ecr
@@ -39,6 +39,7 @@ lib <%= to_lib_namespace(namespace) %>
                             data : Void*,
                             destroy_data : Void* -> Nil,
                             flags : UInt32) : UInt64
+  @[Raises]
   fun g_signal_emit_by_name(instance : Void*, detailed_signal : UInt8*, ...)
 
   # Null terminated strings GType, used by GValue

--- a/src/bindings/g_lib/binding.yml
+++ b/src/bindings/g_lib/binding.yml
@@ -273,3 +273,6 @@ ignore:
  - TreeNode
  - Uri
  - UriParamsIter
+
+execute_callback:
+ - g_main_loop_run

--- a/src/bindings/g_object/binding.yml
+++ b/src/bindings/g_object/binding.yml
@@ -81,5 +81,4 @@ ignore:
  - WeakRef
 
 execute_callback:
- - g_signal_emit_by_name
  - g_signal_emitv

--- a/src/bindings/g_object/binding.yml
+++ b/src/bindings/g_object/binding.yml
@@ -79,3 +79,7 @@ ignore:
  - ParamSpecVariant
  - SignalQuery
  - WeakRef
+
+execute_callback:
+ - g_signal_emit_by_name
+ - g_signal_emitv

--- a/src/generator/binding_config.cr
+++ b/src/generator/binding_config.cr
@@ -7,6 +7,7 @@ module Generator
     getter includes : Set(Path)
     getter handmade : Set(String)
     getter ignore : Set(String)
+    getter execute_callback : Set(String)
 
     getter base_path : Path
 
@@ -26,12 +27,13 @@ module Generator
       end
       @handmade = read_list(data, "handmade")
       @ignore = read_list(data, "ignore")
+      @execute_callback = read_list(data, "execute_callback")
     end
 
     # Constructs an empty binding config
     def initialize(@namespace, @version)
       @includes = Set(Path).new
-      @handmade = @ignore = Set(String).new
+      @execute_callback = @handmade = @ignore = Set(String).new
       @base_path = Path.new(".")
     end
 

--- a/src/generator/lib_gen.cr
+++ b/src/generator/lib_gen.cr
@@ -29,7 +29,7 @@ module Generator
       namespace.functions.each do |func|
         all << generate_c_function(func)
       end
-      all.sort_by! { |el| el.lines.last }
+      all.sort_by!(&.lines.last)
     end
 
     private def type_init_func(info : RegisteredTypeInfo)

--- a/src/generator/lib_gen.cr
+++ b/src/generator/lib_gen.cr
@@ -40,6 +40,7 @@ module Generator
       symbol = func_info.symbol
       with_log_scope("#{to_lib_namespace(func_info.namespace)}.#{symbol}") do
         String.build do |io|
+          io << "@[Raises]\n" if symbol.in? @config.execute_callback
           io << "fun " << symbol
           generate_c_function_args(io, func_info)
           io << " : " << to_lib_type(func_info.return_type, structs_as_void: true)

--- a/src/generator/lib_gen.cr
+++ b/src/generator/lib_gen.cr
@@ -29,7 +29,7 @@ module Generator
       namespace.functions.each do |func|
         all << generate_c_function(func)
       end
-      all.sort!
+      all.sort_by! { |el| el.lines.last }
     end
 
     private def type_init_func(info : RegisteredTypeInfo)

--- a/src/generator/lib_gen.cr
+++ b/src/generator/lib_gen.cr
@@ -40,7 +40,7 @@ module Generator
       symbol = func_info.symbol
       with_log_scope("#{to_lib_namespace(func_info.namespace)}.#{symbol}") do
         String.build do |io|
-          io << "@[Raises]\n" if symbol.in? @config.execute_callback
+          io << "@[Raises]\n" if symbol.in?(@config.execute_callback)
           io << "fun " << symbol
           generate_c_function_args(io, func_info)
           io << " : " << to_lib_type(func_info.return_type, structs_as_void: true)


### PR DESCRIPTION
This PR adds the `execute_callback` key to the yaml file, adding a @[Raising] annotation to the selected functions. This is currently the easiest approach to adding this feature, it could be further improved. For example it might be useful to print warnings when a function mentioned in `execute_callback` does not exist. Also I'm not sure if `execute_callback` is the best name for this, but I guess it's good enough.

Closes #8 