### PR TITLE
Add initialize to Generator::Helpers::KEYWORDS

### DIFF
--- a/src/generator/helpers.cr
+++ b/src/generator/helpers.cr
@@ -1,5 +1,5 @@
 module Generator::Helpers
-  KEYWORDS = {"abstract", "alias", "begin", "def", "end", "enum", "in", "module", "next", "out", "self", "select", "extend"}
+  KEYWORDS = {"abstract", "alias", "begin", "def", "end", "enum", "in", "module", "next", "out", "self", "select", "extend", "initialize"}
 
   def to_get_type_function(struct_info : StructInfo)
     "#{struct_info.namespace.name.underscore}_#{struct_info.name.underscore}_get_type"


### PR DESCRIPTION
Came across a non-initializer method that got generated as `initialize` and failed to compile due to:

```
 638 | def initialize : Bool
           ^---------
Error: this 'initialize' doesn't initialize instance variable '@pointer' of GObject::Object, with OSTree::Sysroot < GObject::Object, rendering it nilable
```

This PR adds `initialize` to the reserved KEYWORDS of Generator::Helpers (so #to_identifier cleans it)!

For context, I was building ostree bindings:

```
namespace: OSTree
version: "1.0"
```

(`ostree_sysroot_initialize` => `def initialize : Bool`)