### PR TITLE
Use Crystal.format instead of shell

### DIFF
--- a/src/generator/generator.cr
+++ b/src/generator/generator.cr
@@ -75,15 +75,6 @@ module Generator
       self.class.name
     end
 
-    def generate(filename : String)
-      output_dir = File.join(Generator.output_dir, module_dir)
-      FileUtils.mkdir_p(output_dir)
-
-      File.open(File.join(output_dir, filename), "w") do |io|
-        generate(io)
-      end
-    end
-
     def with_log_scope(scope_name = scope)
       Generator.push_log_scope(scope_name)
       yield

--- a/src/generator/generator.cr
+++ b/src/generator/generator.cr
@@ -1,5 +1,6 @@
 require "ecr"
 require "log"
+require "compiler/crystal/tools/formatter"
 
 require "../gobject_introspection"
 require "./helpers"
@@ -73,6 +74,15 @@ module Generator
 
     def scope : String
       self.class.name
+    end
+
+    def generate(filename : String)
+      output_dir = File.join(Generator.output_dir, module_dir)
+      FileUtils.mkdir_p(output_dir)
+
+      generated = String.build { |io| generate(io) }
+      formatted = Crystal.format(generated)
+      File.write(File.join(output_dir, filename), formatted)
     end
 
     def with_log_scope(scope_name = scope)

--- a/src/generator/main.cr
+++ b/src/generator/main.cr
@@ -2,7 +2,6 @@ require "colorize"
 require "log"
 require "option_parser"
 require "version_from_shard"
-require "compiler/crystal/tools/formatter"
 
 require "./module_gen"
 require "./binding_config"
@@ -79,12 +78,7 @@ end
 
 private def generate_all
   Generator::BindingConfig.loaded_configs.each_value do |conf|
-    module_gen = Generator::ModuleGen.load(conf)
-    output_dir = File.join(module_gen.output_dir, module_gen.module_dir)
-    FileUtils.mkdir_p(output_dir)
-    generated = String.build { |io| module_gen.generate(io) }
-    formatted = Crystal.format(generated)
-    File.write(File.join(output_dir, module_gen.filename), formatted)
+    Generator::ModuleGen.load(conf).generate
   end
 end
 


### PR DESCRIPTION
This is a small PR which uses `Crystal.format` instead of calling `crystal tool format`.