### PR TITLE
Use `GC.malloc_atomic` to allocate GObjects Wrappers

### DIFF
--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -51,6 +51,16 @@ module <%= namespace_name %>
       <% end %>
     end
 
+    # :nodoc:
+    # Code copied from crystal/src/weak_ref.cr
+    # Allocates this object using malloc_atomic, allowing the GC to run more efficiently.
+    # As GObjects memory is managed using reference counting, we do not need to scan its pointers.
+    def self.allocate
+      ptr = GC.malloc_atomic(instance_sizeof(self)).as(self)
+      set_crystal_type_id(ptr)
+      ptr
+    end
+
     <% if all_properties.any? -%>
       <% render "ecr/gobject_constructor.ecr" %>
     <% end %>

--- a/ecr/struct.ecr
+++ b/ecr/struct.ecr
@@ -32,15 +32,17 @@ module <%= namespace_name %>
       <%= struct_new_method %>
     <% end %>
 
-    # :nodoc:
-    # Code copied from crystal/src/weak_ref.cr
-    # Allocates this object using malloc_atomic, allowing the GC to run more efficiently.
-    # As GObjects memory is managed using reference counting, we do not need to scan its pointers.
-    def self.allocate
-      ptr = GC.malloc_atomic(instance_sizeof(self)).as(self)
-      set_crystal_type_id(ptr)
-      ptr
-    end
+    <% unless object.copyable? %>
+      # :nodoc:
+      # Code copied from crystal/src/weak_ref.cr
+      # Allocates this object using malloc_atomic, allowing the GC to run more efficiently.
+      # As GObjects memory is managed using reference counting, we do not need to scan its pointers.
+      def self.allocate
+        ptr = GC.malloc_atomic(instance_sizeof(self)).as(self)
+        set_crystal_type_id(ptr)
+        ptr
+      end
+    <% end %>
 
     def finalize
       <% if g_error? -%>

--- a/ecr/struct.ecr
+++ b/ecr/struct.ecr
@@ -32,6 +32,16 @@ module <%= namespace_name %>
       <%= struct_new_method %>
     <% end %>
 
+    # :nodoc:
+    # Code copied from crystal/src/weak_ref.cr
+    # Allocates this object using malloc_atomic, allowing the GC to run more efficiently.
+    # As GObjects memory is managed using reference counting, we do not need to scan its pointers.
+    def self.allocate
+      ptr = GC.malloc_atomic(instance_sizeof(self)).as(self)
+      set_crystal_type_id(ptr)
+      ptr
+    end
+
     def finalize
       <% if g_error? -%>
         # FIXME: calling g_error_free causes a double free here, but WTF is also freeing this!?


### PR DESCRIPTION
Allocates glib object-wrappers and non-copyable-struct-wrappers using `malloc_atomic`, allowing the GC to run a little bit more efficiently.