### PR TITLE
Move struct data inside struct class

### DIFF
--- a/ecr/struct.ecr
+++ b/ecr/struct.ecr
@@ -1,7 +1,11 @@
 module <%= namespace_name %>
   <% render_doc(object) -%>
   class <%= type_name %>
-    @pointer : Pointer(Void)
+    <% if !g_error? && object.copyable? %>
+      @data : <%= to_lib_type(object) %>
+    <% else %>
+      @pointer : Pointer(Void)
+    <% end %>
 
     def initialize(pointer : Pointer(Void), transfer : GICrystal::Transfer)
       raise ArgumentError.new("Tried to generate struct with a NULL pointer") if pointer.null?
@@ -20,8 +24,7 @@ module <%= namespace_name %>
                    end
       <% elsif object.copyable? %>
         # Raw structs are always moved to Crystal memory.
-        @pointer = Pointer(Void).malloc(sizeof(<%= to_lib_type(object) %>))
-        @pointer.copy_from(pointer, sizeof(<%= to_lib_type(object) %>))
+        @data = pointer.as(Pointer(<%= to_lib_type(object) %>)).value
         LibGLib.g_free(pointer) if transfer.full?
       <% else %>
         @pointer = pointer
@@ -56,7 +59,11 @@ module <%= namespace_name %>
     <% render_methods %>
 
     def to_unsafe
-      @pointer
+      <% if !g_error? && object.copyable? %>
+        pointerof(@data).as(Void*)
+      <% else %>
+        @pointer
+      <% end %>
     end
   end
 end

--- a/src/generator/method_gen.cr
+++ b/src/generator/method_gen.cr
@@ -149,7 +149,7 @@ module Generator
 
     private def method_c_call_args : String
       args = Array(String).new(@method.args.size + 2) # +2, just in case we need space for `self` and `error`.
-      args << "@pointer" if @method.method?
+      args << "to_unsafe" if @method.method?
       @method.args.each do |arg|
         if arg.direction.out? && arg_used_by_return_type?(arg)
           args << "pointerof(#{to_identifier(arg.name)})"

--- a/src/generator/struct_gen.cr
+++ b/src/generator/struct_gen.cr
@@ -45,8 +45,7 @@ module Generator
         end.join(", ")
         s << ")\n"
 
-        s << "_ptr = Pointer(Void).malloc(" << @struct.bytesize << ")\n"
-        s << "_instance = new(_ptr, GICrystal::Transfer::None)\n"
+        s << "_instance = allocate\n"
         generate_ctor_fields_assignment(s)
         s << "_instance\n"
         s << "end\n"

--- a/src/generator/struct_gen.cr
+++ b/src/generator/struct_gen.cr
@@ -90,7 +90,7 @@ module Generator
       field_type_name(io, field)
       io << LF
 
-      io << "_var = (@pointer + " << field.byteoffset << ").as(Pointer(" << to_lib_type(field_type, structs_as_void: true) << "))\n"
+      io << "_var = (to_unsafe + " << field.byteoffset << ").as(Pointer(" << to_lib_type(field_type, structs_as_void: true) << "))\n"
       if is_pointer
         io << "return if _var.value.null?\n"
       end
@@ -113,7 +113,7 @@ module Generator
       field_type_name(io, field)
       io << ")\n"
 
-      io << "_var = (@pointer + " << field.byteoffset << ").as(Pointer(" << field_lib_type << "))"
+      io << "_var = (to_unsafe + " << field.byteoffset << ").as(Pointer(" << field_lib_type << "))"
       if !is_pointer && field_type.tag.interface?
         iface = field_type.interface
         if iface.is_a?(StructInfo) && iface.boxed?


### PR DESCRIPTION
This PR avoids malloc-ing seperate memory for copyable struct data by moving the data inside the class. This should increase performance a bit. It may be possible to further increase performance by converting the class into a struct, but I currently haven't tested this.