### PR TITLE
Filter struct parameter names

### DIFF
--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -106,8 +106,8 @@ describe "GObject Binding" do
     it "removes out params" do
       subject = Test::Subject.new
       ret = subject.out_param
-      ret.in.should eq(1)
-      ret.begin.should eq(2)
+      ret._in.should eq(1)
+      ret._begin.should eq(2)
     end
   end
 
@@ -240,7 +240,7 @@ describe "GObject Binding" do
 
     it "works on plain structs" do
       subject = Test::Struct.new(begin: 42)
-      subject.begin.should eq(42)
+      subject._begin.should eq(42)
     end
   end
 end

--- a/src/generator/helpers.cr
+++ b/src/generator/helpers.cr
@@ -1,5 +1,5 @@
 module Generator::Helpers
-  KEYWORDS = {"abstract", "alias", "begin", "def", "end", "enum", "in", "module", "next", "out", "self", "select", "extend", "initialize"}
+  KEYWORDS = {"abstract", "alias", "begin", "def", "end", "enum", "in", "module", "next", "out", "self", "select", "extend", "initialize", "finalize"}
 
   def to_get_type_function(struct_info : StructInfo)
     "#{struct_info.namespace.name.underscore}_#{struct_info.name.underscore}_get_type"

--- a/src/generator/struct_gen.cr
+++ b/src/generator/struct_gen.cr
@@ -51,7 +51,7 @@ module Generator
     private def generate_ctor_fields_assignment(io)
       @struct.fields.each do |field|
         field_name = to_identifier(field.name)
-        io << "_instance." << field.name << " = " << field_name << " unless " << field_name << ".nil?\n"
+        io << "_instance." << field_name << " = " << field_name << " unless " << field_name << ".nil?\n"
       end
     end
 
@@ -71,7 +71,7 @@ module Generator
     end
 
     private def generate_getter(io : IO, field : FieldInfo)
-      field_name = field.name
+      field_name = to_identifier(field.name)
       field_type = field.type_info
       is_pointer = field_type.pointer?
 
@@ -99,7 +99,7 @@ module Generator
     end
 
     private def generate_setter(io : IO, field : FieldInfo)
-      field_name = field.name
+      field_name = to_identifier(field.name)
       field_type = field.type_info
       is_pointer = field_type.pointer?
       field_lib_type = to_lib_type(field_type, structs_as_void: true)


### PR DESCRIPTION
While I was trying to find out whether we can actually use crystal structs for GObject structs or not, I was greeted by a compiler error telling me that structs cannot have a `finalize` method. It turned out that [GLib::SourceFuncs has a property called `finalize`](https://libadwaita.geopjr.dev/docs/GLib/SourceFuncs.html#finalize%3AGLib%3A%3AFinalize-instance-method), which crystal would register with the GC.

This PR filters protected keywords from struct parameter names and adds `finalize` as a protected keyword.