### PR TITLE
GC resistant subclasses

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -89,10 +89,6 @@ object pointer into every wrapper it creates, so it can restore the wraper objec
 When the wrapper is collected by the GC it reset this pointer to NULL, so if it appear again in the Crystal world we create
 another wrapper for it. See `Crystal::INSTANCE_QDATA_KEY` constant.
 
-For user made objects inheriting GObject we need another flag, since if the GC collect it all the Crystal data is removed as
-well, so we raise an exception when the user try to restore the Crystal object doing a cast, see
-`Crystal::GC_COLLECTED_QDATA_KEY`.
-
 ## How Struct wrappers works
 
 Currently it creates a wrapper with a copy of the struct always... i.e. it's slow.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,7 @@ GValue as parameter you can pass any supported value. I.e. you can pass e.g. a p
 
 ## GObject inheritance
 
-You can inherit GObjects, when you do so a new type is registered in GObject type system. Crystal objects that inherit
-GObjects must always have a reference in Crystal world, otherwise they will be collected by the GC.
-
-Trying to cast a GObject that was already collected by Crystal GC will result in a `GICrystal::ObjectCollectedError` exception.
-
-Crystal objects that inherit `GObject` returns the same object reference on casts, i.e. no memory allocation is done.
+You can inherit GObjects, when you do so a new type is registered in GObject type system.
 For more examples see the [inheritance tests](spec/inheritance_spec.cr).
 
 ## Declaring GObject signals

--- a/ecr/interface.ecr
+++ b/ecr/interface.ecr
@@ -13,7 +13,7 @@ module <%= namespace_name %>
   class <%= abstract_interface_name(object, false) %> < GObject::Object
     include <%= type_name %>
 
-    GICrystal.declare_new_method(<%= abstract_interface_name(object) %>, g_object_get_qdata, g_object_set_qdata)
+    GICrystal.declare_new_method(g_object_get_qdata, g_object_set_qdata)
 
     # Forbid users to create instances of this.
     private def initialize

--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -20,14 +20,17 @@ module <%= namespace_name %>
     end
     <% elsif class_struct %>
     # :nodoc:
-    def self._register_derived_type(klass : Class, class_init, instance_init)
+    alias LIB_TYPE = <%= to_lib_type(object) %>
+
+    # :nodoc:
+    def self._register_derived_type(klass : Class, instance_size, class_init, instance_init)
       LibGObject.g_type_register_static_simple(g_type, klass.name,
                                                sizeof(<%= to_lib_type(class_struct) %>), class_init,
-                                               sizeof(<%= to_lib_type(object) %>), instance_init, 0)
+                                               instance_size, instance_init, 0)
     end
     <% end %>
 
-    GICrystal.declare_new_method(<%= type_name %>, <%= object.qdata_get_func %>, <%= object.qdata_set_func %>)
+    GICrystal.declare_new_method(<%= object.qdata_get_func %>, <%= object.qdata_set_func %>)
 
     # Initialize a new `<%= type_name %>`.
     def initialize

--- a/src/bindings/g_object/binding.yml
+++ b/src/bindings/g_object/binding.yml
@@ -2,6 +2,7 @@ namespace: GObject
 version: "2.0"
 
 include_before:
+ - gc.cr
  - lib_g_object.cr
  - type.cr
  - signal.cr

--- a/src/bindings/g_object/gc.cr
+++ b/src/bindings/g_object/gc.cr
@@ -1,0 +1,35 @@
+# This file includes the function GC_malloc_uncollectable from bdwgc.
+# It enables us to allocate a block of memory which will not be freed,
+# but which will be scanned for pointers to collectible objects.
+# This allows storing pointers to crystal objects in GObject subclasses.
+
+{% if flag?(:gc_none) || flag?(:wasm32) %}
+  module GC
+    # :nodoc:
+    def self.malloc_uncollectable(size : LibC::SizeT) : Void*
+      LibC.malloc(size)
+    end
+  end
+{% else %}
+  lib LibGC
+    fun malloc_uncollectable = GC_malloc_uncollectable(size : SizeT) : Void*
+  end
+
+  module GC
+    # :nodoc:
+    def self.malloc_uncollectable(size : LibC::SizeT) : Void*
+      LibGC.malloc_uncollectable(size)
+    end
+  end
+{% end %}
+
+module GC
+  # Allocates *size* bytes of uncollectable memory.
+  #
+  # The resulting object may contain pointers and they will be tracked by the GC.
+  #
+  # The memory will not be automatically deallocated when unreferenced.
+  def self.malloc_uncollectable(size : Int) : Void*
+    malloc_uncollectable(LibC::SizeT.new(size))
+  end
+end

--- a/src/bindings/g_object/gi_crystal.cr
+++ b/src/bindings/g_object/gi_crystal.cr
@@ -1,9 +1,4 @@
 module GICrystal
-  # Return true if GC already collected the original wrapper of this object.
-  def gc_collected?(object : GObject::Object) : Bool
-    !LibGObject.g_object_get_qdata(object, GC_COLLECTED_QDATA_KEY).null?
-  end
-
   # Return a pointer to the original wrapper for this object.
   def instance_pointer(object : GObject::Object) : Pointer(Void)
     LibGObject.g_object_get_qdata(object, INSTANCE_QDATA_KEY)
@@ -12,14 +7,12 @@ module GICrystal
   # Finalize this object, called by `GObject::Object#finalize`
   def finalize_instance(object : GObject::Object)
     LibGObject.g_object_set_qdata(object, INSTANCE_QDATA_KEY, Pointer(Void).null)
-    LibGObject.g_object_set_qdata(object, GC_COLLECTED_QDATA_KEY, Pointer(Void).new(0x1))
     LibGObject.g_object_unref(object)
   end
 
   # Finalize this object, called by `GObject::ParamSpec#finalize`
   def finalize_instance(object : GObject::ParamSpec)
     LibGObject.g_param_spec_set_qdata(object, INSTANCE_QDATA_KEY, Pointer(Void).null)
-    LibGObject.g_param_spec_set_qdata(object, GC_COLLECTED_QDATA_KEY, Pointer(Void).new(0x1))
     LibGObject.g_param_spec_unref(object)
   end
 end

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -83,15 +83,6 @@ module GObject
           def initialize
           end
 
-          # TODO: Depends on #26
-          # def do_finalize
-          #   GC.free(self.as(Void*))
-          # end
-          #
-          # macro _register_do_finalize
-          #   \{% raise "Cannot use do_finalize, use finalize instead" %}
-          # end
-
           macro inherited
             \{% raise "Cannot inherit GObject private data class" %}
           end


### PR DESCRIPTION
Extracted from #14 
Requires #26 

This (incomplete) PR allows having pointers to crystal objects in your gobject subclass. This is achieved by splitting the subclass into a pointer class and a data class (which does the actual work).

As previously the `implementation do ... end` macro has been criticised, it has now been removed.
With this (and the current state of #26), the syntax for defining a subclass is as follows:

```crystal
class TestPaintable < GObject::Object
  include Gdk::Paintable

  @[GObject::PrivateDataClass]
  class TestPrivate < self
    @test = "hi"

    def do_snapshot(snapshot, width, height)
      puts "Snapshot: #{width}x#{height}, snapshot: #{snapshot}, test: #{@test}, self: #{self}"
    end
  end
end
```

There only needs to be one class inheriting from the pointer class, having the annotation `PrivateDataClass`.