### PR TITLE
Fix #29

### DIFF
--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -20,8 +20,8 @@ module <%= namespace_name %>
     end
     <% elsif class_struct %>
     # :nodoc:
-    def self._register_derived_type(klass : Class, class_init, instance_init)
-      LibGObject.g_type_register_static_simple(g_type, klass.name,
+    def self._register_derived_type(class_name : String, class_init, instance_init)
+      LibGObject.g_type_register_static_simple(g_type, class_name,
                                                sizeof(<%= to_lib_type(class_struct) %>), class_init,
                                                sizeof(<%= to_lib_type(object) %>), instance_init, 0)
     end

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -18,7 +18,14 @@ private class UserSubject < Test::Subject
   end
 end
 
+class User::Class::With::Colons < GObject::Object
+end
+
 describe "Classes inheriting GObject::Object" do
+  it "can register object with complicated class path (issue #29)" do
+    User::Class::With::Colons.g_type.should_not eq(0)
+  end
+
   it "has their own g_type registered on GLib type system" do
     UserObject.g_type.should_not eq(GObject::Object.g_type)
   end

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -20,7 +20,7 @@ module GObject
 
         def self.g_type : UInt64
           if LibGLib.g_once_init_enter(pointerof(@@_g_type)) != 0
-            g_type = {{ @type.superclass.id }}._register_derived_type({{ @type.id }},
+            g_type = {{ @type.superclass.id }}._register_derived_type("{{ @type.name.gsub(/::/, "-") }}",
               ->_class_init(Pointer(LibGObject::TypeClass), Pointer(Void)),
               ->_instance_init(Pointer(LibGObject::TypeInstance), Pointer(LibGObject::TypeClass)))
 


### PR DESCRIPTION
Closes #29 

Adds a new spec and replaces colons (`::`) in paths with dashes (`-`).
For example `My::User::Type` will be registered as `My-User-Type`.
I tried other characters, but dots (`.`) were forbidden and underscores (`_`) are allowed in crystal, making them ambiguous.