### PR TITLE
Fix #31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Linter
         run: crystal tool format --check
       - name: Run tests
-        run: RSPEC_OPTS="-v --order=random" make oldlibs-test
+        run: G_DEBUG=fatal-warnings RSPEC_OPTS="-v --order=random" make oldlibs-test
       - name: Run tests with -Ddebugmemory
-        run: OLD_LIBS=1 ./bin/spec -Ddebugmemory -v --order=random
+        run: G_DEBUG=fatal-warnings OLD_LIBS=1 ./bin/spec -Ddebugmemory -v --order=random

--- a/ecr/interface.ecr
+++ b/ecr/interface.ecr
@@ -12,20 +12,11 @@ module <%= namespace_name %>
       {% unless @type.annotation(GObject::GeneratedWrapper) %}
         def self._install_iface_<%= namespace_name %>__<%= type_name %>(interface : Pointer(LibGObject::TypeInterface)) : Nil
         end
-
-        macro finished
-          def self._install_ifaces
-            closure = ->_install_iface_<%= namespace_name %>__<%= type_name %>(Pointer(LibGObject::TypeInterface))
-            interface_info = LibGObject::InterfaceInfo.new()
-            interface_info.interface_init = closure.pointer
-            interface_info.interface_finalize = Pointer(Void).null
-            interface_info.interface_data = closure.closure_data
-            LibGObject.g_type_add_interface_static(g_type, <%= namespace_name %>::<%= abstract_interface_name(object, false) %>.g_type, pointerof(interface_info))
-
-            previous_def
-          end
-        end
       {% end %}
+    end
+
+    def self.g_type : UInt64
+      <%= namespace_name %>::<%= abstract_interface_name(object, false) %>.g_type
     end
 
     <% render_properties %>

--- a/spec/interfaces_spec.cr
+++ b/spec/interfaces_spec.cr
@@ -4,6 +4,9 @@ private class UserObjectWithInterface < GObject::Object
   include Test::IfaceVFuncs
 end
 
+private class UserSubjectWithIface < Test::Subject
+end
+
 describe "GObject interfaces" do
   it "can be included" do
     obj = UserObjectWithInterface.new
@@ -31,5 +34,9 @@ describe "GObject interfaces" do
 
   it "have class methods" do
     Test::Iface.class_method
+  end
+
+  it "doesn't reinclude interfaces" do
+    UserSubjectWithIface.new
   end
 end

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -42,7 +42,7 @@ module GObject
         # :nodoc:
         def self._install_ifaces
           {% verbatim do %}
-            {% for ancestor in @type.ancestors %}
+            {% for ancestor in @type.ancestors.uniq %}
               {% if ancestor.module? && ancestor.class.has_method?("g_type") %}
                 closure = ->_install_iface_{{ ancestor.name.gsub(/::/, "__") }}(Pointer(LibGObject::TypeInterface))
                 interface_info = LibGObject::InterfaceInfo.new()

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -41,6 +41,18 @@ module GObject
 
         # :nodoc:
         def self._install_ifaces
+          {% verbatim do %}
+            {% for ancestor in @type.ancestors %}
+              {% if ancestor.module? && ancestor.class.has_method?("g_type") %}
+                closure = ->_install_iface_{{ ancestor.name.gsub(/::/, "__") }}(Pointer(LibGObject::TypeInterface))
+                interface_info = LibGObject::InterfaceInfo.new()
+                interface_info.interface_init = closure.pointer
+                interface_info.interface_finalize = Pointer(Void).null
+                interface_info.interface_data = closure.closure_data
+                LibGObject.g_type_add_interface_static(g_type, {{ ancestor }}.g_type, pointerof(interface_info))
+              {% end %}
+            {% end %}
+          {% end %}
         end
 
         # Cast a `GObject::Object` to this type, returns nil if cast can't be made.


### PR DESCRIPTION
Closes #31 

Takes a different approach to installing interfaces. This is now done inside `object.cr`, not in `interface.ecr`.

With this you can include interfaces as often as you want to. They will only be installed once.