### PR TITLE
Implement unsafe vfuncs

### DIFF
--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -1,9 +1,8 @@
     private macro _register_do_<%= vfunc.name %>
       private def self._vfunc_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
-        <%= vfunc_gi_annotations %>
+        <%-= vfunc_gi_annotations %>
         <%- write_implementations(io) -%>
         <%-= '\n' unless vfunc.args.empty? -%>
-
         %gc_collected = !LibGObject.g_object_get_qdata(%this, GICrystal::GC_COLLECTED_QDATA_KEY).null?
         %instance = LibGObject.g_object_get_qdata(%this, GICrystal::INSTANCE_QDATA_KEY)
         raise GICrystal::ObjectCollectedError.new if %gc_collected || %instance.null?
@@ -18,6 +17,27 @@
     <%- end -%>
         vfunc_ptr = (type_struct.as(Pointer(Void)) + <%= @byte_offset %>).as(Pointer(Pointer(Void)))
         vfunc_ptr.value = (->_vfunc_<%= vfunc.name %>(Pointer(Void)<% proc_args(io) %>)).pointer
+        previous_def
+      end
+    end
+
+    private macro _register_do_<%= vfunc.name %>!
+      private def self._vfunc_<%= vfunc.name %>!(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
+        <%-= vfunc_gi_annotations %>
+        %gc_collected = !LibGObject.g_object_get_qdata(%this, GICrystal::GC_COLLECTED_QDATA_KEY).null?
+        %instance = LibGObject.g_object_get_qdata(%this, GICrystal::INSTANCE_QDATA_KEY)
+        raise GICrystal::ObjectCollectedError.new if %gc_collected || %instance.null?
+
+        %instance.as(self).do_<%= vfunc.name %>!(<% call_user_method_with_lib_args(io) %>)
+      end
+
+    <%- if object.is_a?(InterfaceInfo) -%>
+      def self._install_iface_<%= namespace_name %>__<%= type_name %>(type_struct : Pointer(LibGObject::TypeInterface)) : Nil
+    <%- else -%>
+      def self._class_init(type_struct : Pointer(LibGObject::TypeClass), user_data : Pointer(Void)) : Nil
+    <%- end -%>
+        vfunc_ptr = (type_struct.as(Pointer(Void)) + <%= @byte_offset %>).as(Pointer(Pointer(Void)))
+        vfunc_ptr.value = (->_vfunc_<%= vfunc.name %>!(Pointer(Void)<% proc_args(io) %>)).pointer
         previous_def
       end
     end

--- a/src/generator/vfunc_gen.cr
+++ b/src/generator/vfunc_gen.cr
@@ -64,5 +64,12 @@ module Generator
         args_gi_annotations(io, args)
       end
     end
+
+    private def call_user_method_with_lib_args(io)
+      vfunc.args.join(io, ", ") do |arg|
+        io << "lib_"
+        io << to_identifier(arg.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #33 

With this you can define unsafe vfuncs:
```
class TestObject
  def do_example_vfunc!(some_struct : LibGObject::SomeStruct, some_object : Void*)
  end
end
```
