### PR TITLE
Fix gtk4#27

### DIFF
--- a/src/generator/method_gen.cr
+++ b/src/generator/method_gen.cr
@@ -22,7 +22,7 @@ module Generator
       @crystal_arg_count = @args_strategies.size - @args_strategies.count(&.remove_from_declaration?)
     end
 
-    def ignore?
+    def skip? : Bool
       config.ignore?(@method.symbol)
     end
 

--- a/src/generator/method_holder.cr
+++ b/src/generator/method_holder.cr
@@ -5,7 +5,7 @@ module Generator
     macro render_methods
       each_object_method do |method|
         gen = MethodGen.new(object, method)
-        gen.generate(io) unless gen.ignore?
+        gen.generate(io) unless gen.skip?
       end
     end
 

--- a/src/generator/method_holder.cr
+++ b/src/generator/method_holder.cr
@@ -5,7 +5,7 @@ module Generator
     macro render_methods
       each_object_method do |method|
         gen = MethodGen.new(object, method)
-        gen.generate(io) unless gen.skip?
+        gen.generate(io) unless gen.ignore?
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/hugopl/gtk4.cr/issues/27
I split this into three commits, but if you look at the code changes, there's not really a lot changing.
Custom constructors with no arguments are allowed, unless the object is a struct. This is because copyable structs would need an additional malloc, while there's no performance penalty with GObjects, which are always allocated on the heap.