### PR TITLE
Implement user-transparent GObject enums

### DIFF
--- a/ecr/module.ecr
+++ b/ecr/module.ecr
@@ -40,6 +40,7 @@ module <%= namespace_name %>
         <% render_doc(enum_, value) -%>
         <%= to_type_name(value.name) %> = <%= value.value %>
       <% end %>
+      <% render "ecr/g_type_method.ecr", enum_ %>
     end
   <% end %>
 

--- a/spec/enum_spec.cr
+++ b/spec/enum_spec.cr
@@ -1,0 +1,69 @@
+@[Flags]
+enum TestFlags
+  A = 1
+  B = 2
+  C = 4
+  D = 8
+  BC = 6
+end
+
+enum TestEnum
+  X
+  Y
+  Z
+  Odd_Välue = Int32::MAX
+end
+
+describe "Enums" do
+  it "registers valid gtypes" do
+    TestFlags.g_type.should_not eq(0)
+    TestEnum.g_type.should_not eq(0)
+    TestEnum.g_type.should_not eq(TestFlags.g_type)
+  end
+
+  it "allows retrieving values by name" do
+    enum_class : LibGObject::EnumClass* = LibGObject.g_type_class_ref(TestEnum.g_type).as(LibGObject::EnumClass*)
+    flags_class : LibGObject::FlagsClass* = LibGObject.g_type_class_ref(TestFlags.g_type).as(LibGObject::FlagsClass*)
+
+    x_enum_ptr = LibGObject.g_enum_get_value_by_name(enum_class, "X").as(LibGObject::EnumValue*)
+    x_enum_value = x_enum_ptr.value
+    x_enum_value.value.should eq(TestEnum::X.value)
+    String.new(x_enum_value.value_name).should eq("X")
+
+    odd_enum_ptr = LibGObject.g_enum_get_value_by_name(enum_class, "Odd_Välue").as(LibGObject::EnumValue*)
+    odd_enum_value = odd_enum_ptr.value
+    odd_enum_value.value.should eq(TestEnum::Odd_Välue.value)
+    String.new(odd_enum_value.value_name).should eq("Odd_Välue")
+
+    bc_enum_ptr = LibGObject.g_flags_get_value_by_name(flags_class, "BC").as(LibGObject::FlagsValue*)
+    bc_enum_value = bc_enum_ptr.value
+    bc_enum_value.value.should eq(TestFlags::BC.value)
+    String.new(bc_enum_value.value_name).should eq("BC")
+
+    LibGObject.g_type_class_unref(enum_class)
+    LibGObject.g_type_class_unref(flags_class)
+  end
+
+  it "allows retrieving enum values by value" do
+    enum_class : LibGObject::EnumClass* = LibGObject.g_type_class_ref(TestEnum.g_type).as(LibGObject::EnumClass*)
+    flags_class : LibGObject::FlagsClass* = LibGObject.g_type_class_ref(TestFlags.g_type).as(LibGObject::FlagsClass*)
+
+    x_enum_ptr = LibGObject.g_enum_get_value(enum_class, TestEnum::X).as(LibGObject::EnumValue*)
+    x_enum_value = x_enum_ptr.value
+    x_enum_value.value.should eq(TestEnum::X.value)
+    String.new(x_enum_value.value_name).should eq("X")
+
+    odd_enum_ptr = LibGObject.g_enum_get_value(enum_class, TestEnum::Odd_Välue).as(LibGObject::EnumValue*)
+    odd_enum_value = odd_enum_ptr.value
+    odd_enum_value.value.should eq(TestEnum::Odd_Välue.value)
+    String.new(odd_enum_value.value_name).should eq("Odd_Välue")
+
+    bc_enum_ptr = LibGObject.g_flags_get_first_value(flags_class, TestFlags::BC).as(LibGObject::FlagsValue*)
+    bc_enum_value = bc_enum_ptr.value
+    bc_enum_value.value.should eq(TestFlags::B.value)
+    String.new(bc_enum_value.value_name).should eq("B")
+
+    LibGObject.g_type_class_unref(enum_class)
+    LibGObject.g_type_class_unref(flags_class)
+  end
+end

--- a/spec/enum_spec.cr
+++ b/spec/enum_spec.cr
@@ -1,9 +1,9 @@
 @[Flags]
 enum TestFlags
-  A = 1
-  B = 2
-  C = 4
-  D = 8
+  A  = 1
+  B  = 2
+  C  = 4
+  D  = 8
   BC = 6
 end
 

--- a/src/bindings/g_object/binding.yml
+++ b/src/bindings/g_object/binding.yml
@@ -2,6 +2,7 @@ namespace: GObject
 version: "2.0"
 
 include_before:
+ - enum.cr
  - lib_g_object.cr
  - type.cr
  - signal.cr

--- a/src/bindings/g_object/enum.cr
+++ b/src/bindings/g_object/enum.cr
@@ -1,0 +1,42 @@
+abstract struct Enum
+  @@_g_type : UInt64 = 0
+
+  def self.g_type : UInt64
+    if LibGLib.g_once_init_enter(pointerof(@@_g_type)) != 0
+      {% begin %}
+        test_val = uninitialized self
+        _raise_invalid_enum_type(test_val.value)
+
+        {% values = @type.constants %}
+        enumvals = LibC.malloc(sizeof(LibGObject::EnumValue) * {{values.size + 1}}).as(LibGObject::EnumValue*)
+        {% for val, i in values %}
+          enum_value = LibGObject::EnumValue.new
+          enum_value.value = {{ @type }}::{{ val }}
+          enum_value.value_nick = {{ val.stringify }}
+          enum_value.value_name = {{ val.stringify }}
+          enumvals[{{i}}] = enum_value
+        {% end %}
+        enum_value = LibGObject::EnumValue.new
+        enum_value.value = 0
+        enum_value.value_name = Pointer(LibC::Char).null
+        enum_value.value_nick = Pointer(LibC::Char).null
+        enumvals[{{ values.size }}] = enum_value
+
+        {% type_name = @type.id.gsub(/::/, "-").stringify %}
+        {% if @type.annotation(Flags) %}
+          g_type = LibGObject.g_flags_register_static({{ type_name }}, enumvals.as(LibGObject::FlagsValue*))
+        {% else %}
+          g_type = LibGObject.g_enum_register_static({{ type_name }}, enumvals)
+        {% end %}
+        LibGLib.g_once_init_leave(pointerof(@@_g_type), g_type)
+      {% end %}
+    end
+
+    @@_g_type
+  end
+
+  # :nodoc:
+  def self._raise_invalid_enum_type(i : T) forall T
+    {% raise "Enums used with GLib must use Int32 as their datatype, but #{@type} uses #{T}" unless T == Int32 %}
+  end
+end


### PR DESCRIPTION
This PR implements completely user-transparent enums.
These enums are currently not very useful, but they will be once we have GObject properties (which is something I'm working on currently). Splitting this process of allowing to use properties in GObjects will however ease the review.

Only enums using `Int32` as their underlying datatype are allowed to be used with GObject. Trying to use `Enum.g_type` on an enum not using `Int32` will result in a compile-time error explaining the issue:
```
Error: Enums used with GLib must use Int32 as their datatype, but TestFlags uses UInt8
```

There are already specs (and all current specs pass), so I think this should be ready for review!