### PR TITLE
Implement unsafe vfuncs

### DIFF
--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -21,3 +21,24 @@
         previous_def
       end
     end
+
+    private macro _register_unsafe_do_<%= vfunc.name %>
+      private def self._vfunc_unsafe_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
+        <%-= vfunc_gi_annotations %>
+        %gc_collected = !LibGObject.g_object_get_qdata(%this, GICrystal::GC_COLLECTED_QDATA_KEY).null?
+        %instance = LibGObject.g_object_get_qdata(%this, GICrystal::INSTANCE_QDATA_KEY)
+        raise GICrystal::ObjectCollectedError.new if %gc_collected || %instance.null?
+
+        %instance.as(self).unsafe_do_<%= vfunc.name %>(<% call_user_method_with_lib_args(io) %>)
+      end
+
+    <%- if object.is_a?(InterfaceInfo) -%>
+      def self._install_iface_<%= namespace_name %>__<%= type_name %>(type_struct : Pointer(LibGObject::TypeInterface)) : Nil
+    <%- else -%>
+      def self._class_init(type_struct : Pointer(LibGObject::TypeClass), user_data : Pointer(Void)) : Nil
+    <%- end -%>
+        vfunc_ptr = (type_struct.as(Pointer(Void)) + <%= @byte_offset %>).as(Pointer(Pointer(Void)))
+        vfunc_ptr.value = (->_vfunc_unsafe_<%= vfunc.name %>(Pointer(Void)<% proc_args(io) %>)).pointer
+        previous_def
+      end
+    end

--- a/spec/vfunc_spec.cr
+++ b/spec/vfunc_spec.cr
@@ -13,9 +13,36 @@ private class IfaceVFuncImpl < GObject::Object
   end
 end
 
+private class UnsafeIfaceVFuncImpl < GObject::Object
+  include Test::IfaceVFuncs
+
+  getter int32 = 0
+  getter float32 = 0.0_f32
+  getter float64 = 0.0
+  getter string : String?
+  getter obj : GObject::Object?
+
+  def unsafe_do_vfunc_basic(@int32, @float32, @float64, c_string : Pointer(UInt8), obj : Pointer(Void))
+    @string = String.new(c_string) if c_string
+    @obj = GObject::Object.new(obj, :full)
+  end
+end
+
 describe "GObject vfuncs" do
   it "can receive number parameters" do
     obj = IfaceVFuncImpl.new
+    obj.call_vfunc("vfunc_basic")
+    obj.int32.should eq(1)
+    obj.float32.should eq(2.2_f32)
+    obj.float64.should eq(3.3)
+    obj.string.should eq("string")
+    subject = Test::Subject.cast(obj.obj)
+    subject.ref_count.should eq(1)
+    subject.string.should eq("hey")
+  end
+
+  it "can have unsafe implementations" do
+    obj = UnsafeIfaceVFuncImpl.new
     obj.call_vfunc("vfunc_basic")
     obj.int32.should eq(1)
     obj.float32.should eq(2.2_f32)

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -9,7 +9,7 @@ module GObject
       {% unless @type.annotation(GObject::GeneratedWrapper) %}
         macro method_added(method)
           {% verbatim do %}
-            {% if method.name.starts_with?("do_") %}
+            {% if method.name.starts_with?("do_") || method.name.starts_with?("unsafe_do_") %}
               _register_{{method.name}}
             {% end %}
           {% end %}

--- a/src/generator/vfunc_gen.cr
+++ b/src/generator/vfunc_gen.cr
@@ -64,5 +64,12 @@ module Generator
         args_gi_annotations(io, args)
       end
     end
+
+    private def call_user_method_with_lib_args(io)
+      vfunc.args.join(io, ", ") do |arg|
+        io << "lib_"
+        io << to_identifier(arg.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #38 
Closes #33 

This time, the PR uses `unsafe_do_name` instead of `do_name!`.