### PR TITLE
Filter call names

### DIFF
--- a/ecr/property.ecr
+++ b/ecr/property.ecr
@@ -1,5 +1,5 @@
 <% if prop.flags.writable? -%>
-    def <%= to_method_name(prop.name) %>=(value : <%= prop_type_name %>) : <%= prop_type_name %>
+    def <%= to_call(prop.name) %>=(value : <%= prop_type_name %>) : <%= prop_type_name %>
       <% if prop.type_info.array? -%>
         # handle array
       <% else -%>

--- a/ecr/signal.ecr
+++ b/ecr/signal.ecr
@@ -25,6 +25,6 @@ struct <%= signal_type %> < GObject::Signal
   <% render_emit_method %>
 end
 
-def <%= to_method_name(signal.name) %>_signal
+def <%= to_call(signal.name) %>_signal
   <%= signal_type %>.new(self)
 end

--- a/spec/boxed_struct_spec.cr
+++ b/spec/boxed_struct_spec.cr
@@ -1,0 +1,4 @@
+require "./spec_helper"
+
+describe "Boxed Struct bindings" do
+end

--- a/spec/libtest/test_struct.c
+++ b/spec/libtest/test_struct.c
@@ -1,0 +1,7 @@
+#include "test_struct.h"
+
+void test_struct_initialize(TestStruct* self) {
+}
+
+void test_struct_finalize(TestStruct* self) {
+}

--- a/spec/libtest/test_struct.h
+++ b/spec/libtest/test_struct.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/**
+ * TestPoint:
+ * @x: X
+ * @y: Y
+ *
+ * Used to test simple structs
+ */
+typedef struct _TestPoint {
+  int x;
+  int y;
+} TestPoint;
+
+/**
+ * TestStruct:
+ * @in: A attribute using a invalid Crystal keyword.
+ * @begin: Another attribute using a invalid Crystal keyword.
+ * @point: Another struct member of this struct.
+ * @string: A string
+ *
+ * A plain struct to test stuff
+ */
+typedef struct _TestStruct {
+  gint16 in;
+  gint16 begin;
+  TestPoint* point_ptr;
+  TestPoint point;
+  const char* string;
+} TestStruct;
+
+/**
+ * test_struct_initialize:
+ */
+void test_struct_initialize(TestStruct* self);
+
+/**
+ * test_struct_finalize:
+ */
+void test_struct_finalize(TestStruct* self);
+
+G_END_DECLS

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -6,6 +6,7 @@
 #include "test_flags.h"
 #include "test_iface.h"
 #include "test_regular_enum.h"
+#include "test_struct.h"
 
 G_BEGIN_DECLS
 
@@ -20,35 +21,6 @@ G_BEGIN_DECLS
  * A constant.
  */
 #define TEST_CONSTANT 123
-
-/**
- * TestPoint:
- * @x: X
- * @y: Y
- *
- * Used to test simple structs
- */
-typedef struct _TestPoint {
-  int x;
-  int y;
-} TestPoint;
-
-/**
- * TestStruct:
- * @in: A attribute using a invalid Crystal keyword.
- * @begin: Another attribute using a invalid Crystal keyword.
- * @point: Another struct member of this struct.
- * @string: A string
- *
- * A plain struct to test stuff
- */
-typedef struct _TestStruct {
-  gint16 in;
-  gint16 begin;
-  TestPoint* point_ptr;
-  TestPoint point;
-  const char* string;
-} TestStruct;
 
 /**
  * TestSubject:

--- a/spec/struct_spec.cr
+++ b/spec/struct_spec.cr
@@ -25,4 +25,10 @@ describe "Struct bindings" do
     truct = Test::Struct.new(string: "hey")
     truct.string.should eq("hey")
   end
+
+  it "can bind initialize/finalize methods" do
+    truct = Test::Struct.new
+    truct.responds_to?(:_initialize).should eq(true)
+    truct.responds_to?(:_finalize).should eq(true)
+  end
 end

--- a/src/generator/helpers.cr
+++ b/src/generator/helpers.cr
@@ -1,5 +1,9 @@
 module Generator::Helpers
-  KEYWORDS = {"abstract", "alias", "begin", "def", "end", "enum", "in", "module", "next", "out", "self", "select", "extend", "initialize"}
+  # Keywords not allowed in identifiers
+  ID_KEYWORDS = {"abstract", "alias", "begin", "def", "end", "enum", "in", "module", "next", "out", "self", "select", "extend"}
+
+  # Keywords not allowed in calls
+  CALL_KEYWORDS = {"initialize", "finalize"}
 
   def to_get_type_function(struct_info : StructInfo)
     "#{struct_info.namespace.name.underscore}_#{struct_info.name.underscore}_get_type"
@@ -11,8 +15,13 @@ module Generator::Helpers
   end
 
   def to_identifier(name : String) : String
-    name = name.tr("-", "_") if name.index("-")
-    KEYWORDS.includes?(name) ? "_#{name}" : name
+    name = name.gsub('-', '_')
+    ID_KEYWORDS.includes?(name) ? "_#{name}" : name
+  end
+
+  def to_call(name : String) : String
+    name = name.gsub('-', '_')
+    CALL_KEYWORDS.includes?(name) ? "_#{name}" : name
   end
 
   def to_type_name(name : String) : String
@@ -25,10 +34,6 @@ module Generator::Helpers
     else
       name
     end
-  end
-
-  def to_method_name(name : String) : String
-    name.tr("-", "_")
   end
 
   def abstract_interface_name(iface : InterfaceInfo, include_namespace : Bool = true)
@@ -146,7 +151,7 @@ module Generator::Helpers
   end
 
   def to_crystal_arg_decl(name : String)
-    if KEYWORDS.includes?(name)
+    if ID_KEYWORDS.includes?(name)
       "#{name} _#{name}"
     else
       to_identifier(name)

--- a/src/generator/method_gen.cr
+++ b/src/generator/method_gen.cr
@@ -35,7 +35,7 @@ module Generator
     end
 
     private def method_identifier : String
-      identifier = to_identifier(@method.name)
+      identifier = to_call(@method.name)
       method_flags = @method.flags
       identifier = if method_flags.constructor?
                      "self.#{identifier}"

--- a/src/generator/property_gen.cr
+++ b/src/generator/property_gen.cr
@@ -31,7 +31,7 @@ module Generator
     end
 
     private def prop_getter_method_name : String
-      name = to_method_name(@prop.name)
+      name = to_call(@prop.name)
       @prop.type_info.tag.boolean? ? "#{name}?" : name
     end
   end

--- a/src/generator/struct_gen.cr
+++ b/src/generator/struct_gen.cr
@@ -76,12 +76,12 @@ module Generator
       is_pointer = field_type.pointer?
 
       if is_pointer
-        io << "def " << field_name << "!\n"
+        io << "def " << to_call(field_name) << "!\n"
         io << "self." << field_name << ".not_nil!"
         io << "\nend\n"
       end
 
-      io << "def " << field_name << " : "
+      io << "def " << to_call(field_name) << " : "
       field_type_name(io, field)
       io << LF
 
@@ -104,7 +104,7 @@ module Generator
       is_pointer = field_type.pointer?
       field_lib_type = to_lib_type(field_type, structs_as_void: true)
 
-      io << "def " << field_name << "=(value : "
+      io << "def " << to_call(field_name) << "=(value : "
       field_type_name(io, field)
       io << ")\n"
 


### PR DESCRIPTION
Follow-up to #27 
This time, the call and identifier keywords were separated.