### PR TITLE
Move `cast_methods.ecr` to `object.cr`

### DIFF
--- a/ecr/cast_methods.ecr
+++ b/ecr/cast_methods.ecr
@@ -1,9 +1,0 @@
-# Cast a `GObject::Object` to `<%= type_name %>`, throw `TypeCastError` if cast can't be made.
-def self.cast(obj : GObject::Object) : self
-  cast?(obj) || raise TypeCastError.new("can't cast #{typeof(obj).name} to <%= type_name %>")
-end
-
-# Cast a `GObject::Object` to `<%= type_name %>`, returns nil if cast can't be made.
-def self.cast?(obj : GObject::Object) : self?
-  new(obj.to_unsafe, GICrystal::Transfer::None) unless LibGObject.g_type_check_instance_is_a(obj, g_type).zero?
-end

--- a/ecr/interface.ecr
+++ b/ecr/interface.ecr
@@ -39,6 +39,5 @@ module <%= namespace_name %>
     end
 
     <% render "ecr/g_type_method.ecr" %>
-    <% render "ecr/cast_methods.ecr" %>
   end
 end

--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -77,8 +77,6 @@ module <%= namespace_name %>
       def to_unsafe
         @pointer
       end
-
-      <% render "ecr/cast_methods.ecr" %>
     <% end %>
 
     <% render "ecr/g_type_method.ecr" %>

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -163,5 +163,15 @@ module GObject
     def ref_count : UInt32
       to_unsafe.as(Pointer(LibGObject::Object)).value.ref_count
     end
+
+    # Cast a `GObject::Object` to `self`, throws a `TypeCastError` if the cast can't be made.
+    def self.cast(obj : GObject::Object) : self
+      cast?(obj) || raise TypeCastError.new("can't cast #{typeof(obj).name} to #{self}")
+    end
+
+    # Cast a `GObject::Object` to `self`, returns nil if the cast can't be made.
+    def self.cast?(obj : GObject::Object) : self?
+      new(obj.to_unsafe, GICrystal::Transfer::None) unless LibGObject.g_type_check_instance_is_a(obj, g_type).zero?
+    end
   end
 end


### PR DESCRIPTION
The cast methods only work using `GObject::Object` because they are defined as `def self.cast(obj : GObject::Object)` and the abstract interface classes inherit from `GObject::Object` anyways. Now the cast methods are defined in `object.cr`, simplifying the code.