### PR TITLE
Fix #48

### DIFF
--- a/src/generator/helpers.cr
+++ b/src/generator/helpers.cr
@@ -177,6 +177,7 @@ module Generator::Helpers
       io << to_crystal_type(arg_type_info, include_namespace: true) << nullmark << ','
     end
     io << to_crystal_type(info.return_type, include_namespace: true)
+    io << '?' if info.may_return_null?
   end
 
   def to_crystal_type(tag : TypeTag) : String


### PR DESCRIPTION
Closes #48 

This seems to fix the issue.
Newly generated code:
```crystal
  # Prototype of the function called to create new child models when
  # gtk_tree_list_row_set_expanded() is called.
  #
  # This function can return %NULL to indicate that @item is guaranteed to be
  # a leaf node and will never have children. If it does not have children but
  # may get children later, it should return an empty model that is filled once
  # children arrive.
  alias TreeListModelCreateModelFunc = Proc(GObject::Object, Gio::ListModel?)
```