### PR TITLE
Required an annotation for virtual methods, so it don't break projects with methods starting with `do_`

### DIFF
--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -1,4 +1,4 @@
-    private macro _register_do_<%= vfunc.name %>
+    private macro _register_<%= vfunc.name %>_vfunc
       private def self._vfunc_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
         <%= vfunc_gi_annotations %>
         <%- write_implementations(io) -%>
@@ -22,7 +22,7 @@
       end
     end
 
-    private macro _register_unsafe_do_<%= vfunc.name %>
+    private macro _register_unsafe_<%= vfunc.name %>_vfunc
       private def self._vfunc_unsafe_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
         <%-= vfunc_gi_annotations %>
         %gc_collected = !LibGObject.g_object_get_qdata(%this, GICrystal::GC_COLLECTED_QDATA_KEY).null?

--- a/spec/vfunc_spec.cr
+++ b/spec/vfunc_spec.cr
@@ -9,6 +9,7 @@ private class IfaceVFuncImpl < GObject::Object
   getter string : String?
   getter obj : GObject::Object?
 
+  @[GObject::Virtual]
   def do_vfunc_basic(@int32, @float32, @float64, @string, @obj)
   end
 end
@@ -22,6 +23,7 @@ private class UnsafeIfaceVFuncImpl < GObject::Object
   getter string : String?
   getter obj : GObject::Object?
 
+  @[GObject::Virtual(unsafe: true, name: "vfunc_basic")]
   def unsafe_do_vfunc_basic(@int32, @float32, @float64, c_string : Pointer(UInt8), obj : Pointer(Void))
     @string = String.new(c_string) if c_string
     @obj = GObject::Object.new(obj, :full)


### PR DESCRIPTION
The reason why a release didn't happen yet is because I didn't want to release with this issue of generating a compiler error if the user have a class with a method named `do_...`

So after this I think there's a lot of stuff already for a release :tada: 