### PR TITLE
Crystallize even more docs

### DIFF
--- a/spec/docs_spec.cr
+++ b/spec/docs_spec.cr
@@ -8,6 +8,8 @@ describe "Docs conversion" do
       "# is: `Test::Subject#is_bool?`",
       "# initializer: `Test::Subject.new`",
       "# WARNING: **⚠️ The following code is in c ⚠️**",
+      "# `nil` `true` `false`",
+      "# `Gdk::VulkanContext` Adw::ComboRow",
     ]
     test_subject = File.read("./src/auto/test-1.0/subject.cr")
 

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -46,6 +46,10 @@ G_BEGIN_DECLS
  * }
  * ```
  *
+ * Others:
+ * %NULL %TRUE %FALSE
+ * `GdkVulkanContext` AdwComboRow
+ *
  */
 #define TEST_TYPE_SUBJECT test_subject_get_type()
 G_DECLARE_DERIVABLE_TYPE(TestSubject, test_subject, TEST, SUBJECT, GObject)

--- a/src/generator/doc_repo.cr
+++ b/src/generator/doc_repo.cr
@@ -124,6 +124,15 @@ module Generator
     def crystallize_doc(doc : String) : String
       crystallized_doc = doc
       crystallized_doc = crystallized_doc.gsub(/```([a-zA-Z]+)\n/, "\n\nWARNING: **⚠️ The following code is in \\1 ⚠️**\n```\\1\n")
+
+      crystallized_doc = crystallized_doc.gsub(/%(TRUE|FALSE|NULL)/) do |_, match|
+        case match[1]
+        when "TRUE"  then "`true`"
+        when "FALSE" then "`false`"
+        when "NULL"  then "`nil`"
+        end
+      end
+
       crystallized_doc = crystallized_doc.gsub(/\[([a-zA-Z]+)@([a-zA-Z\.:_]+)\]/) do |_, match|
         split_reference = match[-1].split(/\.|:/)
         identifier = split_reference[-1]
@@ -136,11 +145,16 @@ module Generator
                      elsif identifier.starts_with?("set_") && identifier.size > 4
                        "##{identifier[4..]}="
                      else
-                       "##{identifier}"
+                       "#{split_reference.size == 2 ? "::" : "#"}#{identifier}"
                      end
 
         "`#{split_reference[0..-2].join("::")}#{identifier}`"
       end
+
+      crystallized_doc = crystallized_doc.gsub(/(G[dts]k|Pango|cairo_|graphene_|Adw|Hdy|GtkSource)(\w+\b)/) do |_, match|
+        match.captures.join("::")
+      end
+
       crystallized_doc
     end
 


### PR DESCRIPTION
```
%NULL %TRUE %FALSE => `Nil` `true` `false`
`GdkVulkanContext` => `Gdk::VulkanContext`
AdwComboRow => Adw::ComboRow

+ fix: `Gtk#ListBoxRow` => `Gtk::ListBoxRow`
```

The `(G[dts]k|Pango|cairo_|graphene_|Adw|Hdy|GtkSource)(\w+\b)` regex has been taken and modified from [gtk-rs](https://github.com/gtk-rs/gir/blob/master/src/codegen/doc/format.rs#L170).