### PR TITLE
GC-resistant GObject subclasses

### DIFF
--- a/ecr/gobject_constructor.ecr
+++ b/ecr/gobject_constructor.ecr
@@ -20,3 +20,8 @@ def initialize(<%= gobject_constructor_parameter_declaration %>)
 
   LibGObject.<%= object.qdata_set_func %>(@pointer, GICrystal::INSTANCE_QDATA_KEY, Pointer(Void).new(object_id))
 end
+
+# :nodoc:
+C_TYPE_PROPERTIES = [
+  <%= all_properties.map { |prop| "{name: \"#{prop.name}\", identifier: \"#{to_identifier(prop.name)}\", type: #{to_crystal_type(prop.type_info)}}" }.join(",\n") %>
+]

--- a/ecr/interface.ecr
+++ b/ecr/interface.ecr
@@ -32,7 +32,7 @@ module <%= namespace_name %>
   class <%= abstract_interface_name(object, false) %> < GObject::Object
     include <%= type_name %>
 
-    GICrystal.declare_new_method(<%= abstract_interface_name(object) %>, g_object_get_qdata, g_object_set_qdata)
+    GICrystal.declare_new_method(g_object_get_qdata, g_object_set_qdata)
 
     # Forbid users to create instances of this.
     private def initialize

--- a/ecr/interface.ecr
+++ b/ecr/interface.ecr
@@ -10,7 +10,7 @@ module <%= namespace_name %>
       end
 
       {% unless @type.annotation(GICrystal::GeneratedWrapper) %}
-        def self._install_iface_<%= namespace_name %>__<%= type_name %>(interface : Pointer(LibGObject::TypeInterface)) : Nil
+        private def self._install_iface_<%= namespace_name %>__<%= type_name %>(interface : Pointer(LibGObject::TypeInterface)) : Nil
         end
       {% end %}
     end

--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -56,6 +56,8 @@ module <%= namespace_name %>
 
     <% if all_properties.any? -%>
       <% render "ecr/gobject_constructor.ecr" %>
+    <% else %>
+      C_TYPE_PROPERTIES = [] of String
     <% end %>
 
     <% if object.parent.nil? %>

--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -13,7 +13,7 @@
       end
 
     <%- if object.is_a?(InterfaceInfo) -%>
-      def self._install_iface_<%= namespace_name %>__<%= type_name %>(type_struct : Pointer(LibGObject::TypeInterface)) : Nil
+      private def self._install_iface_<%= namespace_name %>__<%= type_name %>(type_struct : Pointer(LibGObject::TypeInterface)) : Nil
     <%- else -%>
       def self._class_init(type_struct : Pointer(LibGObject::TypeClass), user_data : Pointer(Void)) : Nil
     <%- end -%>
@@ -34,7 +34,7 @@
       end
 
     <%- if object.is_a?(InterfaceInfo) -%>
-      def self._install_iface_<%= namespace_name %>__<%= type_name %>(type_struct : Pointer(LibGObject::TypeInterface)) : Nil
+      private def self._install_iface_<%= namespace_name %>__<%= type_name %>(type_struct : Pointer(LibGObject::TypeInterface)) : Nil
     <%- else -%>
       def self._class_init(type_struct : Pointer(LibGObject::TypeClass), user_data : Pointer(Void)) : Nil
     <%- end -%>

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -14,12 +14,9 @@ private class UserObjectWithCtor < GObject::Object
 end
 
 private class UserSubject < Test::Subject
-  # def initialize(string : String)
-  #   super(string: string)
-  # end
 end
 
-private class UserObjectWithGProperties < GObject::Object
+class UserObjectWithGProperties < GObject::Object
   @[GObject::Property(nick: "STRING", blurb: "A string without meaning")]
   property str_ing : String? = "default"
 
@@ -113,15 +110,13 @@ describe "Classes inheriting GObject::Object" do
   end
 
   it "can call parent generic constructors" do
-    obj = UserSubject.new
-    obj.string = "hey"
+    obj = UserSubject.new(string: "hey")
     LibGObject.g_type_check_instance_is_a(obj, UserSubject.g_type).should eq(1)
     obj.string.should eq("hey")
   end
 
   it "can set GObject properties" do
-    obj = UserObjectWithGProperties.new
-    obj.object = UserObject.new
+    obj = UserObjectWithGProperties.new(object: UserObject.new)
 
     LibGObject.g_object_set(obj, "str-ing", "test value", Pointer(Void).null)
     obj.str_ing.should eq("test value")
@@ -141,8 +136,7 @@ describe "Classes inheriting GObject::Object" do
   end
 
   it "can get GObject properties" do
-    obj = UserObjectWithGProperties.new
-    obj.object = UserObject.new
+    obj = UserObjectWithGProperties.new(object: UserObject.new)
 
     out_string = uninitialized Pointer(LibC::Char)
     LibGObject.g_object_get(obj, "str-ing", pointerof(out_string), Pointer(Void).null)
@@ -171,8 +165,7 @@ describe "Classes inheriting GObject::Object" do
 
   it "emits notify signal on GObject properties access" do
     test_var = 0
-    obj = UserObjectWithGProperties.new
-    obj.object = UserObject.new
+    obj = UserObjectWithGProperties.new(object: UserObject.new)
     signal = obj.notify_signal["signal-test"].connect { test_var += 1 }
 
     test_var.should eq(0)

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -123,6 +123,7 @@ describe "Classes inheriting GObject::Object" do
     obj = UserObjectWithCtor.new
     obj.string = "hey"
     obj.ref_count.should eq(1)
+    LibGObject.g_object_ref(obj)
     obj_wrapper = GObject::Object.new(obj.to_unsafe, :full)
     obj_wrapper.class.should eq(UserObjectWithCtor)
     obj2 = UserObjectWithCtor.cast(obj)

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -10,7 +10,7 @@ private class UserObjectWithCtor < GObject::Object
   getter string : String?
   getter test_union : Int32 | Bool
 
-  private def initialize(*, @string : String?, @[GObject::RefProp] @test_union : Int32 | Bool = true)
+  private def initialize(*, @string : String?, @[GObject::RefProp] @test_union : Int32 | Bool = true, @[GObject::RefProp] @private_class : UserObject? = nil, &)
   end
 end
 
@@ -100,7 +100,7 @@ describe "Classes inheriting GObject::Object" do
   end
 
   it "can have any constructors" do
-    obj = UserObjectWithCtor.new(string: "hey", test_union: true)
+    obj = UserObjectWithCtor.new(string: "hey", test_union: true, private_class: UserObject.new)
     obj.ref_count.should eq(1)
     LibGObject.g_object_ref(obj)
     obj_wrapper = GObject::Object.new(obj.to_unsafe, :full)

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -7,10 +7,11 @@ private class UserFloatRefObject < Test::FloatRef
 end
 
 private class UserObjectWithCtor < GObject::Object
-  property string : String? = "not hey"
-  # def initialize(@string : String)
-  #   super()
-  # end
+  getter string : String?
+  getter test_union : Int32 | Bool
+
+  private def initialize(*, @string : String?, @[GObject::RefProp] @test_union : Int32 | Bool = true)
+  end
 end
 
 private class UserSubject < Test::Subject
@@ -99,14 +100,15 @@ describe "Classes inheriting GObject::Object" do
   end
 
   it "can have any constructors" do
-    obj = UserObjectWithCtor.new
-    obj.string = "hey"
+    obj = UserObjectWithCtor.new(string: "hey", test_union: true)
     obj.ref_count.should eq(1)
     LibGObject.g_object_ref(obj)
     obj_wrapper = GObject::Object.new(obj.to_unsafe, :full)
     obj_wrapper.class.should eq(UserObjectWithCtor)
     obj2 = UserObjectWithCtor.cast(obj)
     obj2.should eq(obj)
+    obj2.string.should eq("hey")
+    obj2.test_union.should eq(true)
   end
 
   it "can call parent generic constructors" do

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -7,7 +7,7 @@ private class UserFloatRefObject < Test::FloatRef
 end
 
 private class UserObjectWithCtor < GObject::Object
-  property string : String = "not hey"
+  property string : String? = "not hey"
   # def initialize(@string : String)
   #   super()
   # end
@@ -29,7 +29,7 @@ end
 
 private class UserObjectWithGProperties < GObject::Object
   @[GObject::Property(nick: "STRING", blurb: "A string without meaning")]
-  property str_ing : String = "default"
+  property str_ing : String? = "default"
 
   @[GObject::Property(nick: "INTEGER", blurb: "An Int32", min: 40, max: 50)]
   property int : Int32 = 42

--- a/spec/inheritance_spec.cr
+++ b/spec/inheritance_spec.cr
@@ -19,13 +19,13 @@ private class UserSubject < Test::Subject
 end
 
 private class UserObjectWithGProperties < GObject::Object
-  @[GObject::Property(nick: "STRING", blurb: "A string without meaning", default: "default")]
+  @[GObject::Property(nick: "STRING", blurb: "A string without meaning")]
   property str_ing : String = "default"
 
-  @[GObject::Property(nick: "INTEGER", blurb: "An Int32", default: 42, min: 40, max: 50)]
+  @[GObject::Property(nick: "INTEGER", blurb: "An Int32", min: 40, max: 50)]
   property int : Int32 = 42
 
-  @[GObject::Property(default: TestFlags::BC)]
+  @[GObject::Property]
   property flags = TestFlags::BC
 
   @[GObject::Property]

--- a/src/bindings/g_object/binding.yml
+++ b/src/bindings/g_object/binding.yml
@@ -2,6 +2,7 @@ namespace: GObject
 version: "2.0"
 
 require_before:
+ - gc.cr
  - enum.cr
  - lib_g_object.cr
  - type.cr

--- a/src/bindings/g_object/gc.cr
+++ b/src/bindings/g_object/gc.cr
@@ -1,0 +1,35 @@
+# This file includes the function GC_malloc_uncollectable from bdwgc.
+# It enables us to allocate a block of memory which will not be freed,
+# but which will be scanned for pointers to collectible objects.
+# This allows storing pointers to crystal objects in GObject subclasses.
+
+{% if flag?(:gc_none) || flag?(:wasm32) %}
+  module GC
+    # :nodoc:
+    def self.malloc_uncollectable(size : LibC::SizeT) : Void*
+      LibC.malloc(size)
+    end
+  end
+{% else %}
+  lib LibGC
+    fun malloc_uncollectable = GC_malloc_uncollectable(size : SizeT) : Void*
+  end
+
+  module GC
+    # :nodoc:
+    def self.malloc_uncollectable(size : LibC::SizeT) : Void*
+      LibGC.malloc_uncollectable(size)
+    end
+  end
+{% end %}
+
+module GC
+  # Allocates *size* bytes of uncollectable memory.
+  #
+  # The resulting object may contain pointers and they will be tracked by the GC.
+  #
+  # The memory will not be automatically deallocated when unreferenced.
+  def self.malloc_uncollectable(size : Int) : Void*
+    malloc_uncollectable(LibC::SizeT.new(size))
+  end
+end

--- a/src/bindings/g_object/lib_g_object.cr
+++ b/src/bindings/g_object/lib_g_object.cr
@@ -48,4 +48,8 @@ lib LibGObject
 
   # Null terminated strings GType, used by GValue
   fun g_strv_get_type : UInt64
+
+  fun g_object_add_toggle_ref(object : Void*, notify : (Void*, Void*, Int32 ->), data : Void*)
+  fun g_object_remove_toggle_ref(object : Void*, notify : (Void*, Void*, Int32 ->), data : Void*)
+  fun g_object_weak_ref(object : Void*, notify : (Void*, Void* ->), data : Void*)
 end

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -138,6 +138,9 @@ module GObject
         # A state storing the return value of ClosureDataManager::Register
         @_g_retainer = Pointer(Void*).null
 
+        # C object
+        @pointer = Pointer(Void).null
+
         def self.g_type : UInt64
           if LibGLib.g_once_init_enter(pointerof(@@_g_type)) != 0
             g_type = {{ @type.superclass.id }}._register_derived_type("{{ @type.name.gsub(/::/, "-") }}",

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -419,7 +419,7 @@ module GObject
           end
         end
 
-        def self._g_toggle_notify(data : Void*, _gobject : Void*, is_last_ref : Int32) : Nil
+        private def self._g_toggle_notify(data : Void*, _gobject : Void*, is_last_ref : Int32) : Nil
           data = data.as(Void**)
           is_last_ref = GICrystal.to_bool(is_last_ref)
 

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -243,7 +243,7 @@ module GObject
                       {% end %}
                     {% else %}
                       raw = GObject::Value.raw({{ var_type }}.g_type, gvalue)
-                      self.{{ var }} = raw.as({{ var_type }})
+                      self.{{ var }} = raw.as({{ var.type }})
                     {% end %}
                 {% end %}
               {% end %}

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -436,6 +436,7 @@ module GObject
           if type.value.g_type == @@_g_type
             # Allocate crystal proxy object and add toggle reference to keep it and the c object alive
             this = self.allocate
+            this_ptr = this.as(Void*)
             _g_toggle_notify(pointerof(this.@_g_retainer).as(Void*), instance.as(Void*), 0)
             LibGObject.g_object_add_toggle_ref(instance, G_TOGGLE_NOTIFY__, pointerof(this.@_g_retainer).as(Void*))
 

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -118,7 +118,10 @@ module GObject
 
               case property_id
               {% for var, i in instance_vars %}
-                {% if @type.has_method?(var.name.stringify) %}
+                {% if @type.has_method?(var.name.stringify + "?") %}
+                  when {{ i + 1 }}
+                    GObject::Value.set_g_value(gvalue.as(LibGObject::Value*), self.{{ var }}?)
+                {% elsif @type.has_method?(var.name.stringify) %}
                   when {{ i + 1 }}
                     GObject::Value.set_g_value(gvalue.as(LibGObject::Value*), self.{{ var }})
                 {% end %}

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -435,7 +435,7 @@ module GObject
             data.value = GICrystal::ToggleRefManager.register(data.as(Void*))
           end
         end
-        G_TOGGLE_NOTIFY__ = ->_g_toggle_notify(Void*, Void*, Int32)
+        private G_TOGGLE_NOTIFY__ = ->_g_toggle_notify(Void*, Void*, Int32)
 
         # :nodoc:
         def self._install_ifaces

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -89,7 +89,7 @@ module GObject
                 {% has_setter = @type.has_method?("#{var.name}=") %}
                 {% raise "GObject properties need to have a getter and/or a setter" unless has_getter || has_setter %}
 
-                flags = GObject::ParamFlags::StaticName | GObject::ParamFlags::StaticBlurb | GObject::ParamFlags::ExplicitNotify
+                flags = GObject::ParamFlags::StaticName | GObject::ParamFlags::StaticNick | GObject::ParamFlags::StaticBlurb | GObject::ParamFlags::ExplicitNotify
                 flags |= GObject::ParamFlags::Deprecated unless {{ !!var.annotation(Deprecated) }}
                 flags |= GObject::ParamFlags::Readable if {{ has_getter }}
                 flags |= GObject::ParamFlags::Writable if {{ has_setter }}

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -480,6 +480,10 @@ module GObject
         end
 
         def finalize
+          {% if flag?(:debugmemory) %}
+            LibC.printf("~%s at %p - ref count: %d\n", self.class.name.to_unsafe, self, ref_count)
+          {% end %}
+
           LibGObject.g_object_set_qdata(self, GICrystal::INSTANCE_QDATA_KEY, Pointer(Void).null)
           LibGObject.g_object_set_qdata(self, GICrystal::GC_COLLECTED_QDATA_KEY, Pointer(Void).new(0x1))
           LibGObject.g_object_remove_toggle_ref(self, G_TOGGLE_NOTIFY__, pointerof(@_g_retainer).as(Void*))

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -135,7 +135,7 @@ module GObject
         # ParamSpec pointers for the GObject properties in the object
         @@_g_param_specs = Pointer(LibGObject::ParamSpec*).null
 
-        # A state storing the return value of ClosureDataManager::Register
+        # A state storing the return value of ToggleRefManager.register
         @_g_retainer = Pointer(Void*).null
 
         # C object

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -94,7 +94,7 @@ module GObject
                 {% raise "GObject properties need to have a getter and/or a setter" unless has_getter || has_setter %}
 
                 flags = GObject::ParamFlags::StaticName | GObject::ParamFlags::StaticNick | GObject::ParamFlags::StaticBlurb | GObject::ParamFlags::ExplicitNotify
-                flags |= GObject::ParamFlags::Deprecated unless {{ !!var.annotation(Deprecated) }}
+                flags |= GObject::ParamFlags::Deprecated unless {{ var.annotation(Deprecated) == nil }}
                 flags |= GObject::ParamFlags::Readable if {{ has_getter }}
                 flags |= GObject::ParamFlags::Writable if {{ has_setter }}
                 flags |= GObject::ParamFlags::Construct if {{ var.has_default_value? && has_setter }}

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -83,6 +83,7 @@ module GObject
                 name = {{ var.name.gsub(/\_/, "-").stringify }}.to_unsafe
                 nick = {{ property["nick"] }}.try(&.to_unsafe) || Pointer(LibC::Char).null
                 blurb = {{ property["blurb"] }}.try(&.to_unsafe) || Pointer(LibC::Char).null
+                default = {{ var.default_value }}
                 {% other_args = property.named_args.to_a.reject { |arg| ["nick", "blurb"].includes?(arg[0].stringify) } %}
 
                 {% has_getter = @type.has_method?(var.name.stringify) || @type.has_method?(var.name.stringify + "?") %}
@@ -96,7 +97,7 @@ module GObject
 
                 # Finally register the type to GLib.
                 # The given varible name has its underscores converted to dashes.
-                pspec = GObject.create_param_spec({{ var.type }}, name, nick, blurb, flags, {{ other_args.map { |tuple| "#{tuple[0]}: #{tuple[1]}".id }.splat }})
+                pspec = GObject.create_param_spec({{ var.type }}, name, nick, blurb, flags, default, {{ other_args.map { |tuple| "#{tuple[0]}: #{tuple[1]}".id }.splat }})
                 @@_g_param_specs[{{ i }}] = pspec.as(LibGObject::ParamSpec*)
                 LibGObject.g_object_class_install_property(klass, {{ i + 1 }}, pspec)
               {% end %}

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -479,6 +479,7 @@ module GObject
           instance.as(self)
         end
 
+        # :nodoc:
         def finalize
           {% if flag?(:debugmemory) %}
             LibC.printf("~%s at %p - ref count: %d\n", self.class.name.to_unsafe, self, ref_count)

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -405,7 +405,7 @@ module GObject
           return if LibGObject.g_type_check_instance_is_a(obj, g_type).zero?
 
           # If the object was collected by Crystal GC but still alive in C world we can't bring
-          # the crystal object form the dead.
+          # the crystal object from the dead.
           gc_collected = GICrystal.gc_collected?(obj)
           instance = GICrystal.instance_pointer(obj)
           raise GICrystal::ObjectCollectedError.new if gc_collected || instance.null?

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -399,15 +399,6 @@ module GObject
         protected def _constructed : Nil
           {% verbatim do %}
             {% begin %}
-              if @pointer.as(LibGObject::TypeInstance*).value.g_class.value.g_type == @@_g_type
-                # Set default values of non-gobject-properties or non-writable gobject-properties
-                {% for var in @type.instance_vars %}
-                  {% if var.has_default_value? && var.name != "pointer" && var.name != "_g_retainer" && var.name != "_gi_initialize_args" && (!var.annotation(GObject::Property) || !@type.has_method?("#{var.name}=")) %}
-                    @{{var.name}} = {{var.default_value}}
-                  {% end %}
-                {% end %}
-              end
-
               previous_vfunc
 
               if @pointer.as(LibGObject::TypeInstance*).value.g_class.value.g_type == @@_g_type
@@ -444,10 +435,7 @@ module GObject
           # This code should only be run once (protection for subclasses of crystal gobject subclasses)
           if type.value.g_type == @@_g_type
             # Allocate crystal proxy object and add toggle reference to keep it and the c object alive
-            this_ptr = GC.malloc(instance_sizeof(self))
-            this = this_ptr.as(self)
-            set_crystal_type_id(this_ptr)
-            GC.add_finalizer(this)
+            this = self.allocate
             _g_toggle_notify(pointerof(this.@_g_retainer).as(Void*), instance.as(Void*), 0)
             LibGObject.g_object_add_toggle_ref(instance, G_TOGGLE_NOTIFY__, pointerof(this.@_g_retainer).as(Void*))
 

--- a/src/bindings/g_object/type.cr
+++ b/src/bindings/g_object/type.cr
@@ -24,8 +24,8 @@ module GObject
   TYPE_STRV      = LibGObject.g_strv_get_type
 
   # :nodoc:
-  def self.create_param_spec(klass : String.class, name, nick, blurb, flags, default : String? = nil) : Void*
-    LibGObject.g_param_spec_string(name, nick, blurb, default || "", flags)
+  def self.create_param_spec(klass : String?.class, name, nick, blurb, flags, default : String? = nil) : Void*
+    LibGObject.g_param_spec_string(name, nick, blurb, default, flags)
   end
 
   # :nodoc:

--- a/src/bindings/g_object/type.cr
+++ b/src/bindings/g_object/type.cr
@@ -24,6 +24,11 @@ module GObject
   TYPE_STRV      = LibGObject.g_strv_get_type
 
   # :nodoc:
+  def self.create_param_spec(klass : String.class, name, nick, blurb, flags, default)
+    {% raise "GObject properties cannot be defined as non-nil strings.\nIn most cases, you can use the following definition:\nproperty! var : String?" %}
+  end
+
+  # :nodoc:
   def self.create_param_spec(klass : String?.class, name, nick, blurb, flags, default : String? = nil) : Void*
     LibGObject.g_param_spec_string(name, nick, blurb, default, flags)
   end
@@ -71,6 +76,11 @@ module GObject
   # :nodoc:
   def self.create_param_spec(klass : Float64.class, name, nick, blurb, flags, default : Float64? = nil, *, min : Float64 = Float64::MIN, max : Float64 = Float64::MAX) : Void*
     LibGObject.g_param_spec_double(name, nick, blurb, min, max, default || 0_f64, flags)
+  end
+
+  # :nodoc:
+  def self.create_param_spec(klass : GObject::Object.class, name, nick, blurb, flags, default)
+    {% raise "GObject properties cannot be defined as non-nil GObjects.\nIn most cases, you can use the following definition:\nproperty! var : Some::GObject?" %}
   end
 
   # :nodoc:

--- a/src/bindings/g_object/type.cr
+++ b/src/bindings/g_object/type.cr
@@ -24,62 +24,62 @@ module GObject
   TYPE_STRV      = LibGObject.g_strv_get_type
 
   # :nodoc:
-  def self.create_param_spec(klass : String.class, name, nick, blurb, flags, *, default : String = "") : Void*
-    LibGObject.g_param_spec_string(name, nick, blurb, default, flags)
+  def self.create_param_spec(klass : String.class, name, nick, blurb, flags, default : String? = nil) : Void*
+    LibGObject.g_param_spec_string(name, nick, blurb, default || "", flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Bool.class, name, nick, blurb, flags, *, default : Bool = false) : Void*
-    LibGObject.g_param_spec_boolean(name, nick, blurb, default, flags)
+  def self.create_param_spec(klass : Bool.class, name, nick, blurb, flags, default : Bool? = nil) : Void*
+    LibGObject.g_param_spec_boolean(name, nick, blurb, default || false, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Int8.class, name, nick, blurb, flags, *, min : Int8 = Int8::MIN, max : Int8 = Int8::MAX, default : Int8 = 0i8) : Void*
-    LibGObject.g_param_spec_char(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : Int8.class, name, nick, blurb, flags, default : Int8? = nil, *, min : Int8 = Int8::MIN, max : Int8 = Int8::MAX) : Void*
+    LibGObject.g_param_spec_char(name, nick, blurb, min, max, default || 0_i8, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : UInt8.class, name, nick, blurb, flags, *, min : UInt8 = UInt8::MIN, max : UInt8 = UInt8::MAX, default : UInt8 = 0u8) : Void*
-    LibGObject.g_param_spec_uchar(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : UInt8.class, name, nick, blurb, flags, default : UInt8? = nil, *, min : UInt8 = UInt8::MIN, max : UInt8 = UInt8::MAX) : Void*
+    LibGObject.g_param_spec_uchar(name, nick, blurb, min, max, default || 0_u8, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Int32.class, name, nick, blurb, flags, *, min : Int32 = Int32::MIN, max : Int32 = Int32::MAX, default : Int32 = 0) : Void*
-    LibGObject.g_param_spec_int(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : Int32.class, name, nick, blurb, flags, default : Int32? = nil, *, min : Int32 = Int32::MIN, max : Int32 = Int32::MAX) : Void*
+    LibGObject.g_param_spec_int(name, nick, blurb, min, max, default || 0_i32, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : UInt32.class, name, nick, blurb, flags, *, min : UInt32 = UInt32::MIN, max : UInt32 = UInt32::MAX, default : UInt32 = 0u32) : Void*
-    LibGObject.g_param_spec_uint(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : UInt32.class, name, nick, blurb, flags, default : UInt32? = nil, *, min : UInt32 = UInt32::MIN, max : UInt32 = UInt32::MAX) : Void*
+    LibGObject.g_param_spec_uint(name, nick, blurb, min, max, default || 0_u32, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Int64.class, name, nick, blurb, flags, *, min : Int64 = Int64::MIN, max : Int64 = Int64::MAX, default : Int64 = 0i64) : Void*
-    LibGObject.g_param_spec_int64(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : Int64.class, name, nick, blurb, flags, default : Int64? = nil, *, min : Int64 = Int64::MIN, max : Int64 = Int64::MAX) : Void*
+    LibGObject.g_param_spec_int64(name, nick, blurb, min, max, default || 0_i64, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : UInt64.class, name, nick, blurb, flags, *, min : UInt64 = UInt64::MIN, max : UInt64 = UInt64::MAX, default : UInt64 = 0u64) : Void*
-    LibGObject.g_param_spec_uint64(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : UInt64.class, name, nick, blurb, flags, default : UInt64? = nil, *, min : UInt64 = UInt64::MIN, max : UInt64 = UInt64::MAX) : Void*
+    LibGObject.g_param_spec_uint64(name, nick, blurb, min, max, default || 0_u64, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Float32.class, name, nick, blurb, flags, *, min : Float32 = Float32::MIN, max : Float32 = Float32::MAX, default : Float32 = 0f32) : Void*
-    LibGObject.g_param_spec_float(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : Float32.class, name, nick, blurb, flags, default : Float32? = nil, *, min : Float32 = Float32::MIN, max : Float32 = Float32::MAX) : Void*
+    LibGObject.g_param_spec_float(name, nick, blurb, min, max, default || 0_f32, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Float64.class, name, nick, blurb, flags, *, min : Float64 = Float64::MIN, max : Float64 = Float64::MAX, default : Float64 = 0.0) : Void*
-    LibGObject.g_param_spec_double(name, nick, blurb, min, max, default, flags)
+  def self.create_param_spec(klass : Float64.class, name, nick, blurb, flags, default : Float64? = nil, *, min : Float64 = Float64::MIN, max : Float64 = Float64::MAX) : Void*
+    LibGObject.g_param_spec_double(name, nick, blurb, min, max, default || 0_f64, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : GObject::Object?.class, name, nick, blurb, flags) : Void*
+  def self.create_param_spec(klass : GObject::Object?.class, name, nick, blurb, flags, default : Nil = nil) : Void*
     LibGObject.g_param_spec_object(name, nick, blurb, type_not_nil!(klass).g_type, flags)
   end
 
   # :nodoc:
-  def self.create_param_spec(klass : Enum.class, name, nick, blurb, flags, *, default : Enum? = nil) : Void*
+  def self.create_param_spec(klass : Enum.class, name, nick, blurb, flags, default : Enum? = nil) : Void*
     if klass._is_flags_enum?
       LibGObject.g_param_spec_flags(name, nick, blurb, klass.g_type, default || 0, flags)
     else

--- a/src/bindings/g_object/type.cr
+++ b/src/bindings/g_object/type.cr
@@ -84,6 +84,11 @@ module GObject
   end
 
   # :nodoc:
+  def self.create_param_spec(klass : GObject::Object?.class, name, nick, blurb, flags, default : GObject::Object)
+    {% raise "GObject properties holding GObjects cannot hold default values" %}
+  end
+
+  # :nodoc:
   def self.create_param_spec(klass : GObject::Object?.class, name, nick, blurb, flags, default : Nil = nil) : Void*
     LibGObject.g_param_spec_object(name, nick, blurb, type_not_nil!(klass).g_type, flags)
   end

--- a/src/bindings/g_object/value.cr
+++ b/src/bindings/g_object/value.cr
@@ -28,14 +28,15 @@ module GObject
     # :nodoc:
     def self.set_g_value(ptr : Pointer(LibGObject::Value), value) : Nil
       case value
+      when Nil              then # skip
       when Bool             then LibGObject.g_value_set_boolean(ptr, value)
       when Float32          then LibGObject.g_value_set_float(ptr, value)
       when Float64          then LibGObject.g_value_set_double(ptr, value)
       when Int32            then LibGObject.g_value_set_int(ptr, value)
       when Int64            then LibGObject.g_value_set_int64(ptr, value)
       when Int8             then LibGObject.g_value_set_schar(ptr, value)
-      when GObject::Object? then LibGObject.g_value_set_object(ptr, value.try(&.to_unsafe) || Pointer(Void).null)
-      when String?          then LibGObject.g_value_set_string(ptr, value)
+      when GObject::Object  then LibGObject.g_value_set_object(ptr, value)
+      when String           then LibGObject.g_value_set_string(ptr, value)
       when UInt32           then LibGObject.g_value_set_uint(ptr, value)
       when UInt64           then LibGObject.g_value_set_uint64(ptr, value)
       when UInt8            then LibGObject.g_value_set_uchar(ptr, value)
@@ -64,7 +65,7 @@ module GObject
       when Int32              then TYPE_INT
       when Int64              then TYPE_INT64
       when Int8               then TYPE_CHAR
-      when GObject::Object?   then TYPE_OBJECT
+      when GObject::Object    then TYPE_OBJECT
       when String             then TYPE_STRING
       when UInt32             then TYPE_UINT
       when UInt64             then TYPE_UINT64

--- a/src/bindings/g_object/value.cr
+++ b/src/bindings/g_object/value.cr
@@ -28,19 +28,19 @@ module GObject
     # :nodoc:
     def self.set_g_value(ptr : Pointer(LibGObject::Value), value) : Nil
       case value
-      when Bool          then LibGObject.g_value_set_boolean(ptr, value)
-      when Float32       then LibGObject.g_value_set_float(ptr, value)
-      when Float64       then LibGObject.g_value_set_double(ptr, value)
-      when Int32         then LibGObject.g_value_set_int(ptr, value)
-      when Int64         then LibGObject.g_value_set_int64(ptr, value)
-      when Int8          then LibGObject.g_value_set_schar(ptr, value)
-      when Object        then LibGObject.g_value_set_object(ptr, value)
-      when String        then LibGObject.g_value_set_string(ptr, value)
-      when UInt32        then LibGObject.g_value_set_uint(ptr, value)
-      when UInt64        then LibGObject.g_value_set_uint64(ptr, value)
-      when UInt8         then LibGObject.g_value_set_uchar(ptr, value)
-      when GLib::Variant then LibGObject.g_value_set_variant(ptr, value)
-      when ParamSpec     then LibGObject.g_value_set_param(ptr, value)
+      when Bool             then LibGObject.g_value_set_boolean(ptr, value)
+      when Float32          then LibGObject.g_value_set_float(ptr, value)
+      when Float64          then LibGObject.g_value_set_double(ptr, value)
+      when Int32            then LibGObject.g_value_set_int(ptr, value)
+      when Int64            then LibGObject.g_value_set_int64(ptr, value)
+      when Int8             then LibGObject.g_value_set_schar(ptr, value)
+      when GObject::Object? then LibGObject.g_value_set_object(ptr, value.try(&.to_unsafe) || Pointer(Void).null)
+      when String           then LibGObject.g_value_set_string(ptr, value)
+      when UInt32           then LibGObject.g_value_set_uint(ptr, value)
+      when UInt64           then LibGObject.g_value_set_uint64(ptr, value)
+      when UInt8            then LibGObject.g_value_set_uchar(ptr, value)
+      when GLib::Variant    then LibGObject.g_value_set_variant(ptr, value)
+      when ParamSpec        then LibGObject.g_value_set_param(ptr, value)
       when Enum
         if value.class._is_flags_enum?
           LibGObject.g_value_set_flags(ptr, value)
@@ -64,7 +64,7 @@ module GObject
       when Int32              then TYPE_INT
       when Int64              then TYPE_INT64
       when Int8               then TYPE_CHAR
-      when Object             then TYPE_OBJECT
+      when GObject::Object?   then TYPE_OBJECT
       when String             then TYPE_STRING
       when UInt32             then TYPE_UINT
       when UInt64             then TYPE_UINT64

--- a/src/bindings/g_object/value.cr
+++ b/src/bindings/g_object/value.cr
@@ -28,20 +28,21 @@ module GObject
     # :nodoc:
     def self.set_g_value(ptr : Pointer(LibGObject::Value), value) : Nil
       case value
-      when Nil              then # skip
-      when Bool             then LibGObject.g_value_set_boolean(ptr, value)
-      when Float32          then LibGObject.g_value_set_float(ptr, value)
-      when Float64          then LibGObject.g_value_set_double(ptr, value)
-      when Int32            then LibGObject.g_value_set_int(ptr, value)
-      when Int64            then LibGObject.g_value_set_int64(ptr, value)
-      when Int8             then LibGObject.g_value_set_schar(ptr, value)
-      when GObject::Object  then LibGObject.g_value_set_object(ptr, value)
-      when String           then LibGObject.g_value_set_string(ptr, value)
-      when UInt32           then LibGObject.g_value_set_uint(ptr, value)
-      when UInt64           then LibGObject.g_value_set_uint64(ptr, value)
-      when UInt8            then LibGObject.g_value_set_uchar(ptr, value)
-      when GLib::Variant    then LibGObject.g_value_set_variant(ptr, value)
-      when ParamSpec        then LibGObject.g_value_set_param(ptr, value)
+      when Nil             then nil
+      when Bool            then LibGObject.g_value_set_boolean(ptr, value)
+      when Float32         then LibGObject.g_value_set_float(ptr, value)
+      when Float64         then LibGObject.g_value_set_double(ptr, value)
+      when Int32           then LibGObject.g_value_set_int(ptr, value)
+      when Int64           then LibGObject.g_value_set_int64(ptr, value)
+      when Int8            then LibGObject.g_value_set_schar(ptr, value)
+      when GObject::Object then LibGObject.g_value_set_object(ptr, value)
+      when String          then LibGObject.g_value_set_string(ptr, value)
+      when UInt32          then LibGObject.g_value_set_uint(ptr, value)
+      when UInt64          then LibGObject.g_value_set_uint64(ptr, value)
+      when UInt8           then LibGObject.g_value_set_uchar(ptr, value)
+      when GLib::Variant   then LibGObject.g_value_set_variant(ptr, value)
+      when ParamSpec       then LibGObject.g_value_set_param(ptr, value)
+      when Pointer(Void)   then LibGObject.g_value_set_pointer(ptr, value)
       when Enum
         if value.class._is_flags_enum?
           LibGObject.g_value_set_flags(ptr, value)
@@ -73,6 +74,7 @@ module GObject
       when Enumerable(String) then TYPE_STRV
       when GLib::Variant      then TYPE_VARIANT
       when ParamSpec          then TYPE_PARAM
+      when Pointer(Void)      then TYPE_POINTER
       when Enum
         if value.class._is_flags_enum?
           TYPE_FLAGS
@@ -108,6 +110,7 @@ module GObject
       when TYPE_PARAM   then ParamSpec.new(LibGObject.g_value_get_param(ptr), :none)
       when TYPE_ENUM    then LibGObject.g_value_get_enum(ptr)
       when TYPE_FLAGS   then LibGObject.g_value_get_flags(ptr)
+      when TYPE_POINTER then LibGObject.g_value_get_pointer(ptr)
       when TYPE_OBJECT
         object_ptr = LibGObject.g_value_get_object(ptr)
         object_ptr.null? ? nil : GObject::Object.new(object_ptr, :none)

--- a/src/bindings/g_object/value.cr
+++ b/src/bindings/g_object/value.cr
@@ -35,7 +35,7 @@ module GObject
       when Int64            then LibGObject.g_value_set_int64(ptr, value)
       when Int8             then LibGObject.g_value_set_schar(ptr, value)
       when GObject::Object? then LibGObject.g_value_set_object(ptr, value.try(&.to_unsafe) || Pointer(Void).null)
-      when String           then LibGObject.g_value_set_string(ptr, value)
+      when String?          then LibGObject.g_value_set_string(ptr, value)
       when UInt32           then LibGObject.g_value_set_uint(ptr, value)
       when UInt64           then LibGObject.g_value_set_uint64(ptr, value)
       when UInt8            then LibGObject.g_value_set_uchar(ptr, value)
@@ -100,7 +100,6 @@ module GObject
       when TYPE_FLOAT   then LibGObject.g_value_get_float(ptr)
       when TYPE_INT     then LibGObject.g_value_get_int(ptr)
       when TYPE_INT64   then LibGObject.g_value_get_int64(ptr)
-      when TYPE_STRING  then String.new(LibGObject.g_value_get_string(ptr))
       when TYPE_UCHAR   then LibGObject.g_value_get_uchar(ptr)
       when TYPE_UINT    then LibGObject.g_value_get_uint(ptr)
       when TYPE_UINT64  then LibGObject.g_value_get_uint64(ptr)
@@ -111,6 +110,9 @@ module GObject
       when TYPE_OBJECT
         object_ptr = LibGObject.g_value_get_object(ptr)
         object_ptr.null? ? nil : GObject::Object.new(object_ptr, :none)
+      when TYPE_STRING
+        ptr = LibGObject.g_value_get_string(ptr)
+        ptr.null? ? nil : String.new(ptr)
       else
         raise ArgumentError.new("Cannot obtain raw value for g_type #{g_type}")
       end

--- a/src/generator/object_gen.cr
+++ b/src/generator/object_gen.cr
@@ -80,7 +80,7 @@ module Generator
     def render_qdata_optimized_new_method(io : IO)
       return if !object.inherits?("GObject") && !object.inherits?("GParam")
 
-      io << "GICrystal.declare_new_method(" << type_name << ',' << object.qdata_get_func << ',' << object.qdata_set_func << ")\n"
+      io << "GICrystal.declare_new_method(" << object.qdata_get_func << ',' << object.qdata_set_func << ")\n"
     end
   end
 end

--- a/src/gi-crystal.cr
+++ b/src/gi-crystal.cr
@@ -1,4 +1,5 @@
 require "./gi_crystal/closure_data_manager"
+require "./gi_crystal/toggle_ref_manager"
 require "./gi_crystal/util"
 
 module GICrystal

--- a/src/gi_crystal/toggle_ref_manager.cr
+++ b/src/gi_crystal/toggle_ref_manager.cr
@@ -1,0 +1,57 @@
+module GICrystal
+  # :nodoc:
+  # This class is used to toggle GObject subclasses' references between a strong and weak state.
+  # This is achieved using a doubly linked list.
+  # Because this implementation is meant to be fast, Crystal::PointerLinkedList could not be used
+  # as it does not return pointers to the nodes, which would be needed.
+  module ToggleRefManager
+    @@linked_list = DoublyLinkedList(Void*).new
+
+    def self.register(data : Void*) : Void*
+      @@linked_list.add(data)
+    end
+
+    def self.deregister(node : Void*) : Nil
+      @@linked_list.remove(node)
+    end
+  end
+
+  # :nodoc:
+  class DoublyLinkedList(T)
+    private struct Node(T)
+      property prev : Node(T)*
+      property next : Node(T)*
+      property value : T
+
+      def initialize(@prev : Node(T)*, @next : Node(T)*, @value : T)
+      end
+    end
+
+    @head : Node(T)* = Pointer(Node(T)).null
+
+    def remove(node : Pointer(Void)) : Nil
+      {% if flag?(:debugmemory) %}
+        puts "Deregistering #{node} from ToggleRefManager"
+      {% end %}
+
+      node_value = node.as(Node(T)*).value
+      node_value.prev.value = node_value.prev.value.tap { |prev_node| prev_node.next = node_value.next } unless node_value.prev.null?
+      node_value.next.value = node_value.next.value.tap { |next_node| next_node.prev = node_value.prev } unless node_value.next.null?
+      @head = node_value.prev if node.as(Node(T)*) == @head
+      GC.free(node)
+    end
+
+    def add(data : T) : Pointer(Void)
+      node_ptr = Pointer(Node(T)).malloc(1)
+
+      {% if flag?(:debugmemory) %}
+        puts "Registering #{data} on ToggleRefManager as #{node_ptr.as(Void*)}"
+      {% end %}
+
+      node_ptr.value = Node(T).new(@head, Pointer(Node(T)).null, data)
+      @head.value = @head.value.tap { |head| head.next = node_ptr } unless @head.null?
+      @head = node_ptr
+      node_ptr.as(Void*)
+    end
+  end
+end

--- a/src/gi_crystal/toggle_ref_manager.cr
+++ b/src/gi_crystal/toggle_ref_manager.cr
@@ -1,57 +1,15 @@
 module GICrystal
   # :nodoc:
   # This class is used to toggle GObject subclasses' references between a strong and weak state.
-  # This is achieved using a doubly linked list.
-  # Because this implementation is meant to be fast, Crystal::PointerLinkedList could not be used
-  # as it does not return pointers to the nodes, which would be needed.
   module ToggleRefManager
-    @@linked_list = DoublyLinkedList(Void*).new
-
     def self.register(data : Void*) : Void*
-      @@linked_list.add(data)
+      node = GC.malloc_uncollectable(sizeof(Void*))
+      node.as(Void**).value = data
+      node
     end
 
     def self.deregister(node : Void*) : Nil
-      @@linked_list.remove(node)
-    end
-  end
-
-  # :nodoc:
-  class DoublyLinkedList(T)
-    private struct Node(T)
-      property prev : Node(T)*
-      property next : Node(T)*
-      property value : T
-
-      def initialize(@prev : Node(T)*, @next : Node(T)*, @value : T)
-      end
-    end
-
-    @head : Node(T)* = Pointer(Node(T)).null
-
-    def remove(node : Pointer(Void)) : Nil
-      {% if flag?(:debugmemory) %}
-        puts "Deregistering #{node} from ToggleRefManager"
-      {% end %}
-
-      node_value = node.as(Node(T)*).value
-      node_value.prev.value = node_value.prev.value.tap { |prev_node| prev_node.next = node_value.next } unless node_value.prev.null?
-      node_value.next.value = node_value.next.value.tap { |next_node| next_node.prev = node_value.prev } unless node_value.next.null?
-      @head = node_value.prev if node.as(Node(T)*) == @head
       GC.free(node)
-    end
-
-    def add(data : T) : Pointer(Void)
-      node_ptr = Pointer(Node(T)).malloc(1)
-
-      {% if flag?(:debugmemory) %}
-        puts "Registering #{data} on ToggleRefManager as #{node_ptr.as(Void*)}"
-      {% end %}
-
-      node_ptr.value = Node(T).new(@head, Pointer(Node(T)).null, data)
-      @head.value = @head.value.tap { |head| head.next = node_ptr } unless @head.null?
-      @head = node_ptr
-      node_ptr.as(Void*)
     end
   end
 end

--- a/src/gi_crystal/toggle_ref_manager.cr
+++ b/src/gi_crystal/toggle_ref_manager.cr
@@ -5,10 +5,19 @@ module GICrystal
     def self.register(data : Void*) : Void*
       node = GC.malloc_uncollectable(sizeof(Void*))
       node.as(Void**).value = data
+
+      {% if flag?(:debugmemory) %}
+        puts "Registering #{data} on ToggleRefManager as #{node}"
+      {% end %}
+
       node
     end
 
     def self.deregister(node : Void*) : Nil
+      {% if flag?(:debugmemory) %}
+        puts "Deregistering #{node} on ToggleRefManager"
+      {% end %}
+
       GC.free(node)
     end
   end

--- a/src/gi_crystal/util.cr
+++ b/src/gi_crystal/util.cr
@@ -107,7 +107,7 @@ module GICrystal
     end
   end
 
-  # This declare the `new` method on a instance of type *type*, *qdata_get_func* and *qdata_set_func* are functions used
+  # This declare the `new` method on a instance of type *self*, *qdata_get_func* and *qdata_set_func* are functions used
   # to set/get qdata on objects, e.g. `g_object_get_qdata`/`g_object_set_qdata` for GObjects.
   #
   # GICrystal stores two qdatas in objects on following keys:
@@ -120,7 +120,7 @@ module GICrystal
   # `GC_COLLECTED_QDATA_KEY` is used to avoid to restore a wrapper that was already collected by GC.
   #
   # This is mainly used for `GObject::Object`, since `GObject::ParamSpec` doesn't support casts on GICrystal.
-  macro declare_new_method(type, qdata_get_func, qdata_set_func)
+  macro declare_new_method(qdata_get_func, qdata_set_func)
     # :nodoc:
     def self.new(pointer : Pointer(Void), transfer : GICrystal::Transfer) : self
       # Try to recover the Crystal instance if any


### PR DESCRIPTION
This PR allows GObject subclasses to be GC-resistant.
Actually, the biggest part of this PR is allowing GObjects to be created from C (g_object_new) without fearing the GC, which requires creating the crystal object from C and retrieving it in the constructor, not creating the crystal object and then setting the pointer.
This time, the user does not need to create multiple classes, manage references (or something similar) becuase the PR uses toggle refs.
A toggle ref is basically a reference telling us whether there are other references besides it or not. If other references exist, we put a pointer to the object in some global array or remove it otherwise.

Additionally, the last two commits add support for defining one `initialize` method per class. The arguments of the method are exposed as construct-only GObject properties, so you can set them even from C. Because GObject properties alone are maybe not as versatile as some classes require it, you can also use the new `RefProp` annotation. Here's how this looks in action:
```crystal
private class UserObjectWithCtor < GObject::Object
  getter string : String?
  getter test_union : Int32 | Bool

  private def initialize(*, @string : String?, @[GObject::RefProp] @test_union : Int32 | Bool = true, @[GObject::RefProp] private_class : UserObject? = nil, &)
  end
end
```

What you can see is:
- Every initialize method needs to accept a block and be private, but that's just to ensure it is not called instead of the `self.new` method.
- There's one GObject property (`@string`), which you would be able to set even in a gtk .ui file.
- There are two args annotated with `GObject::RefProp`. For these args, only a `Pointer(Void)` to a variable is transferred via a GObject property. With this mechanism, most crystal types can be transferred over GObject for constructing.

You can now initialize it:
```crystal
UserObjectWithCtor.new(some_c_property: 2, test_union: 19)
```
This `self.new` method allows setting all GObject properties (defined in C or Crystal) and all initialize arguments in one method.

---

As a little demonstration, I have created a blueprint for an app I am currently working on:
```
using Gtk 4.0;

template Mangaba-UI-ComicListItem : Gtk.Box {
  orientation: vertical;

  Gtk.Overlay {
    margin-bottom: 4;

    .Mangaba-UI-ComicCover {
      texture: bind Mangaba-UI-ComicListItem.texture;
      comic-size: Thumbnail;
      halign: center;
      styles ["card"]
    }

    [overlay]
    Gtk.CheckButton {
      halign: end;
      valign: end;
      visible: bind Mangaba-UI-ComicListItem.is-selection-mode;
      styles ["selection-mode"]
    }
  }

  Gtk.Label {
    label: bind Mangaba-UI-ComicListItem.title;
    wrap: true;
    justify: center;
    lines: 2;
    ellipsize: middle;
    wrap-mode: word_char;
    max-width-chars: 15;
  }

  Gtk.Label {
    label: bind Mangaba-UI-ComicListItem.subtitle;
    ellipsize: middle;
    max-width-chars: 15;
    styles ["dim-label", "caption"]
  }
}
```

Which results in this window:
![Bildschirmfoto vom 2022-09-09 20-51-11](https://user-images.githubusercontent.com/14961554/189508503-7032889d-4314-4544-a4c9-aa59500e03ac.png)

---

To allow this PR to work, multiple breaking changes had to be made and I expect most GObject subclasses to break.
