### PR TITLE
Allow chaining up unsafe vfuncs

### DIFF
--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -39,7 +39,10 @@
       def self._class_init(type_struct : Pointer(LibGObject::TypeClass), user_data : Pointer(Void)) : Nil
     <%- end -%>
         vfunc_ptr = (type_struct.as(Pointer(Void)) + <%= @byte_offset %>).as(Pointer(Pointer(Void)))
+        @@_gi_parent_vfunc_<%= vfunc.name %> = Proc(Pointer(Void), <% generate_lib_types(io, vfunc) %><%= return_type %>).new(vfunc_ptr.value, Pointer(Void).null) unless vfunc_ptr.value.null?
         vfunc_ptr.value = (->_vfunc_unsafe_<%= vfunc.name %>(Pointer(Void)<% proc_args(io) %>)).pointer
         previous_def
       end
+
+      @@_gi_parent_vfunc_<%= vfunc.name %> : Proc(Pointer(Void), <% generate_lib_types(io, vfunc) %><%= return_type %>)? = nil
     end

--- a/spec/libtest/test_iface_vfuncs.c
+++ b/spec/libtest/test_iface_vfuncs.c
@@ -5,7 +5,17 @@
 
 G_DEFINE_INTERFACE(TestIfaceVFuncs, test_iface_vfuncs, G_TYPE_OBJECT)
 
+static guint32 test_iface_vfuncs_default_vfunc_bubble_up(TestIfaceVFuncs* iface) {
+  return 0xDEADBEEF;
+}
+
+static guint32 test_iface_vfuncs_default_vfunc_bubble_up_with_args(TestIfaceVFuncs* iface, guint32 a) {
+  return a + 1;
+}
+
 static void test_iface_vfuncs_default_init(TestIfaceVFuncsInterface* iface) {
+  iface->vfunc_bubble_up = test_iface_vfuncs_default_vfunc_bubble_up;
+  iface->vfunc_bubble_up_with_args = test_iface_vfuncs_default_vfunc_bubble_up_with_args;
 }
 
 gchar* test_iface_vfuncs_call_vfunc(TestIfaceVFuncs* self, const char* name) {
@@ -30,6 +40,16 @@ gchar* test_iface_vfuncs_call_vfunc(TestIfaceVFuncs* self, const char* name) {
 
     TestRegularEnum enum_retval = iface->vfunc_return_enum(self);
     buffer = g_enum_to_string(TEST_TYPE_REGULAR_ENUM, enum_retval);
+  } else if (!strcmp(name, "vfunc_bubble_up")) {
+    g_return_val_if_fail(iface->vfunc_bubble_up, NULL);
+
+    iface->vfunc_bubble_up(self);
+    buffer = g_strdup("success");
+  } else if (!strcmp(name, "vfunc_bubble_up_with_args")) {
+    g_return_val_if_fail(iface->vfunc_bubble_up_with_args, NULL);
+
+    iface->vfunc_bubble_up_with_args(self, 5);
+    buffer = g_strdup("success");
   } else
     g_warning("bad vfunc name: %s", name);
 

--- a/spec/libtest/test_iface_vfuncs.h
+++ b/spec/libtest/test_iface_vfuncs.h
@@ -31,6 +31,19 @@ struct _TestIfaceVFuncsInterface {
   char* (*vfunc_return_string)(TestIfaceVFuncs* self);
 
   /**
+   * TestIfaceVFuncsInterface::vfunc_bubble_up
+   * @self: Self
+   */
+  guint32 (*vfunc_bubble_up)(TestIfaceVFuncs* self);
+
+  /**
+   * TestIfaceVFuncsInterface::vfunc_bubble_up_with_args
+   * @self: Self
+   * @a: A uint32
+   */
+  guint32 (*vfunc_bubble_up_with_args)(TestIfaceVFuncs* self, guint32 a);
+
+  /**
    * TestIfaceVFuncsInterface::vfunc_return_enum
    * @self: Self
    */

--- a/src/bindings/g_object/object.cr
+++ b/src/bindings/g_object/object.cr
@@ -414,6 +414,28 @@ module GObject
       {% end %}
     end
 
+    macro previous_vfunc(*args)
+      \{% begin %}
+        %func = @@_gi_parent_vfunc_\{{ (@def.annotation(GObject::Virtual)[:name] || @def.name.gsub(/^do_/, "")).id }}
+        {% if args.empty? %}
+          %func.try &.call(self.to_unsafe, \{{ @def.args.map { |arg| arg.internal_name || arg.name }.splat }})
+        {% else %}
+          %func.try &.call(self.to_unsafe, {{ *args }})
+        {% end %}
+      \{% end %}
+    end
+
+    macro previous_vfunc!(*args)
+      \{% begin %}
+        %func = @@_gi_parent_vfunc_\{{ (@def.annotation(GObject::Virtual)[:name] || @def.name.gsub(/^do_/, "")).id }}.not_nil!
+        {% if args.empty? %}
+          %func.call(self.to_unsafe, \{{ @def.args.map { |arg| arg.internal_name || arg.name }.splat }})
+        {% else %}
+          %func.call(self.to_unsafe, {{ *args }})
+        {% end %}
+      \{% end %}
+    end
+
     # Declares a GObject signal.
     #
     # Supported signal parameter types are:

--- a/src/generator/box_helper.cr
+++ b/src/generator/box_helper.cr
@@ -58,7 +58,6 @@ module Generator
         # they are structs
         arg_type = to_lib_type(arg.type_info, structs_as_void: true)
         arg_type = "Pointer(#{arg_type})" if is_signal && arg_type == "Void"
-        arg_name = to_identifier(arg.name)
         io << arg_type << ", "
       end
     end

--- a/src/generator/box_helper.cr
+++ b/src/generator/box_helper.cr
@@ -50,6 +50,19 @@ module Generator
       end
     end
 
+    def generate_lib_types(io : IO, callable : CallableInfo)
+      is_signal = callable.is_a?(SignalInfo)
+
+      callable.args.each do |arg|
+        # If arg_type is Void, it's probably a struct, GObjIntrospection doesn't inform that signal args are pointer when
+        # they are structs
+        arg_type = to_lib_type(arg.type_info, structs_as_void: true)
+        arg_type = "Pointer(#{arg_type})" if is_signal && arg_type == "Void"
+        arg_name = to_identifier(arg.name)
+        io << arg_type << ", "
+      end
+    end
+
     def arg_strategies_to_proc_param_string(io : IO, callable : CallableInfo, strategies : Array(ArgStrategy)) : Nil
       strategies.each do |arg_strategy|
         next if arg_strategy.remove_from_declaration?


### PR DESCRIPTION
This PR allows calling the previous vfunc of a class inside an unsafe vfunc definition (taken from specs):
```crystal
  @[GObject::Virtual(unsafe: true, name: "vfunc_bubble_up")]
  def vfunc_bubble_up : UInt32
    ret = previous_vfunc!
    raise "Funny number not found" unless ret == 0xDEADBEEF
    ret
  end

  @[GObject::Virtual(unsafe: true, name: "vfunc_bubble_up_with_args")]
  def vfunc_bubble_up_with_args(a : UInt32) : UInt32
    ret = previous_vfunc!(a + 1)
    raise "Wrong number returned" unless ret == 7
    ret
  end
```

There's `previous_vfunc` and `previous_vfunc(*args)` which calls the previous vfunc if it exists or returns nil and there's `previous_vfunc!` as well as `previous_vfunc!(*args)` which raise an error if there is no previous vfunc and then call it.

This is required because many vfuncs require the user to [chain them up](https://valadoc.org/gobject-introspection-1.0/GI.VFuncInfoFlags.MUST_CHAIN_UP.html).

I found out about this while creating a subclass of `Adw::ApplicationWindow` - which has very weird results because the `constructed` vfunc was not properly chained up and the window never really initialized.

Because #64 always overrides the `constructed` vfunc, many of these unexpected results will occur if we don't provide a way to chain them up (`constructed` has the flag `MUST_CHAIN_UP`).

Maybe it would be a good idea to check whether `MUST_CHAIN_UP` vfuncs have been chained up in the future.