### PR TITLE
Do not render module base error class if the module doesn't declare any error.

### DIFF
--- a/ecr/module.ecr
+++ b/ecr/module.ecr
@@ -27,9 +27,11 @@ module <%= namespace_name %>
     alias <%= to_type_name(callback.name) %> = <%= callable_to_crystal_proc(callback) %>
   <% end %>
 
+  <% if declare_error? %>
   # Base class for all errors in this module.
   class <%= namespace_name %>Error < GLib::Error
   end
+  <% end %>
 
   # Enums
   <% enums.each do |enum_| %>

--- a/src/generator/module_gen.cr
+++ b/src/generator/module_gen.cr
@@ -162,5 +162,9 @@ module Generator
 
       values.first.value.zero?
     end
+
+    private def declare_error? : Bool
+      enums.any?(&.error_domain)
+    end
   end
 end


### PR DESCRIPTION

Fix #79