### PR TITLE
Add lib definition for LibGLib.g_bytes_new_static.

### DIFF
--- a/src/bindings/g_lib/lib_g_lib.cr
+++ b/src/bindings/g_lib/lib_g_lib.cr
@@ -18,4 +18,9 @@ lib LibGLib
   fun g_slist_nth(list : SList*, n : UInt32) : SList*
   fun g_slist_free(list : SList*)
   fun g_slist_free_full(list : SList*, free_func : Proc(Void*, Nil))
+
+  # GBytes
+  # This function is used by some bindings of other modules like
+  # GTK widget template and Gio GResource.
+  fun g_bytes_new_static(data : Void*, size : LibC::SizeT) : Void*
 end


### PR DESCRIPTION
There's no bindings for this function but it's used by other modules.