### PR TITLE
Render parameters in documentation in Crystal style, i.e. no @ symbol.

### DIFF
--- a/spec/docs_spec.cr
+++ b/spec/docs_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe "Docs conversion" do
   it "converted the docs to crystal" do
-    expected_results = [
+    expected_results = {
       "# getter: `Test::Subject#out_param`",
       "# setter: `Test::Subject#str_list=`",
       "# is: `Test::Subject#is_bool?`",
@@ -10,7 +10,10 @@ describe "Docs conversion" do
       "# WARNING: **⚠️ The following code is in c ⚠️**",
       "# `nil` `true` `false`",
       "# `Gdk::VulkanContext` Adw::ComboRow",
-    ]
+      "# parameter: *parameter_42*",
+      "# email_is_not_a_parameter: foo@example.com",
+    }
+
     test_subject = File.read("./src/auto/test-1.0/subject.cr")
 
     expected_results.each do |doc|

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -37,6 +37,10 @@ G_BEGIN_DECLS
  *
  * initializer: [ctor@Test.Subject.new]
  *
+ * parameter: @parameter_42
+ *
+ * email_is_not_a_parameter: foo@example.com
+ *
  * code block:
  * ```c
  * #include <stdio.h>

--- a/src/generator/doc_repo.cr
+++ b/src/generator/doc_repo.cr
@@ -124,7 +124,7 @@ module Generator
     def crystallize_doc(doc : String) : String
       crystallized_doc = doc
       crystallized_doc = crystallized_doc.gsub(/```([a-zA-Z]+)\n/, "\n\nWARNING: **⚠️ The following code is in \\1 ⚠️**\n```\\1\n")
-
+      crystallized_doc = crystallized_doc.gsub(/\s@(\w[\w\d_]*)\b/, " *\\1*")
       crystallized_doc = crystallized_doc.gsub(/%(TRUE|FALSE|NULL)/) do |_, match|
         case match[1]
         when "TRUE"  then "`true`"
@@ -151,6 +151,7 @@ module Generator
         "`#{split_reference[0..-2].join("::")}#{identifier}`"
       end
 
+      # FIXME: Get this list of modules form the generator itself instead of hardcode them
       crystallized_doc = crystallized_doc.gsub(/(G[dts]k|Pango|cairo_|graphene_|Adw|Hdy|GtkSource)(\w+\b)/) do |_, match|
         match.captures.join("::")
       end


### PR DESCRIPTION
The doc gen could be improved *a lot*, most of the things with very simple patches like this one.

Before:
![image](https://user-images.githubusercontent.com/727809/235820639-db9d144f-79d4-4914-ad1a-4a60078c795f.png)


After:
![image](https://user-images.githubusercontent.com/727809/235820572-a0623971-d671-4d55-975a-3db1f0f59150.png)
