### PR TITLE
Let struct bindings allocated on help to obey `-Ddebugmemory` flag.

### DIFF
--- a/ecr/heap_wrapper_struct.ecr
+++ b/ecr/heap_wrapper_struct.ecr
@@ -29,6 +29,9 @@ module <%= namespace_name %>
 
     <% if object.boxed? %>
     def finalize
+      {% if flag?(:debugmemory) %}
+      LibC.printf("~%s at %p\n", self.class.name, self)
+      {% end %}
       LibGObject.g_boxed_free(<%= type_name %>.g_type, self)
     end
     <% end %>

--- a/spec/boxed_struct_spec.cr
+++ b/spec/boxed_struct_spec.cr
@@ -1,4 +1,13 @@
 require "./spec_helper"
 
+@[NoInline]
+private def create_boxed : Nil
+  Test::BoxedStruct.return_boxed_struct("hey")
+end
+
 describe "Boxed Struct bindings" do
+  it "doesn't crash on finalize method" do
+    create_boxed
+    GC.collect
+  end
 end


### PR DESCRIPTION
The added test was only useful for manual testing, i.e. I could run the test and check the message.