### PR TITLE
Do not generate a ref_count call on finalizers when -Ddebugmemory is on.

### DIFF
--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -63,7 +63,7 @@ module <%= namespace_name %>
       # (i.e. its memory is freed).
       def finalize
         {% if flag?(:debugmemory) %}
-        LibC.printf("~%s at %p - ref count: %d\n", self.class.name.to_unsafe, self, ref_count)
+        LibC.printf("~%s at %p\n", self.class.name.to_unsafe, self)
         {% end %}
         GICrystal.finalize_instance(self)
       end


### PR DESCRIPTION
Not all objects have a `ref_count` method.

Later I plan to move these printfs to something like `GICrystal.notify_finalize(obj)`, so type specific details (like ref_count) can be printed in overloads of this function.