### PR TITLE
Add an ignore_constants binding config setting

### DIFF
--- a/BINDING_YML.md
+++ b/BINDING_YML.md
@@ -38,6 +38,10 @@ the HarfBuzz library, if you just want to not generate a binding for a specific 
 
 List of C functions that may execute a callback, so the generator adds a `@[Raises]` annotation to it.
 
+## ignore_constants (list of strings)
+
+List of C `#define`s that the generator will ignore.
+
 ## types (list of BindingTypes)
 
 List of types that require extra configuration, like be removed from generation, have methods removed, etc. Note that the

--- a/ecr/module.ecr
+++ b/ecr/module.ecr
@@ -17,8 +17,10 @@ require "./<%= inc %>"
 
 module <%= namespace_name %>
   <% constants.each do |const| -%>
-    <% render_doc(const) -%>
-    <%= const.name %> = <%= const.literal %>
+    <% unless config.ignore_constants.includes? const.name %>
+      <% render_doc(const) -%>
+      <%= const.name %> = <%= const.literal %>
+    <% end %>
   <% end %>
 
   # Callbacks

--- a/spec/const_spec.cr
+++ b/spec/const_spec.cr
@@ -1,0 +1,19 @@
+require "./spec_helper"
+
+describe "constant bindings" do
+  it "ignores constants according to binding.yml" do
+    responds = true
+    {% unless Test.has_constant? :IGNORED_CONSTANT %}
+      responds = false
+    {% end %}
+    responds.should eq(false)
+  end
+
+  it "doesn't ignore all constants" do
+    responds = false
+    {% if Test.has_constant? :NON_IGNORED_CONSTANT %}
+      responds = true
+    {% end %}
+    responds.should eq(true)
+  end
+end

--- a/spec/libtest/test_const.h
+++ b/spec/libtest/test_const.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/**
+ * TEST_IGNORED_CONSTANT:
+ * A constant ignored in the binding config.
+ */
+#define TEST_IGNORED_CONSTANT 123
+
+/**
+ * TEST_NON_IGNORED_CONSTANT:
+ * A constant.
+ */
+#define TEST_NON_IGNORED_CONSTANT 123
+
+G_END_DECLS

--- a/spec/libtest_binding.yml
+++ b/spec/libtest_binding.yml
@@ -1,6 +1,9 @@
 namespace: Test
 version: "1.0"
 
+ignore_constants:
+  - IGNORED_CONSTANT
+
 types:
   Struct:
     ignore_fields:

--- a/src/bindings/g_lib/binding.yml
+++ b/src/bindings/g_lib/binding.yml
@@ -13,6 +13,9 @@ require_after:
 - variant.cr
 - variant_dict.cr
 
+ignore_constants:
+  - C_STD_VERSION
+
 types:
   Array:
     ignore: true

--- a/src/generator/binding_config.cr
+++ b/src/generator/binding_config.cr
@@ -56,6 +56,7 @@ module GeneratorNamespaceRenamedDueToACrystalBug
     getter types = Hash(String, TypeConfig).new
     getter lib_ignore = Set(String).new
     getter execute_callback = Set(String).new
+    getter ignore_constants = Set(String).new
 
     class_getter loaded_configs = Hash(String, BindingConfig).new
 


### PR DESCRIPTION
Closes #87

I wasn't sure if it would be better to filter out constants in `gobject_introspection/namespace.cr` or filter them out in `module.ecr`. I went with filtering them out in ECR so that the filtered constants are still visible to `GObjectIntrospection::Namespace`.

I made the PR a draft because the binding.yml documentation needs to be updated. I also couldn't get the test suite to run on an M1 mac, so I couldn't verify that tests still pass.