### PR TITLE
Fix compilation for vfuncs returning nullable objects or strings.

### DIFF
--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -1,3 +1,4 @@
+    <%= method_gi_annotations -%>
     private macro _register_<%= vfunc.name %>_vfunc(impl_method_name)
       private def self._vfunc_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
         <%= vfunc_gi_annotations %>
@@ -23,6 +24,7 @@
       end
     end
 
+    <%= method_gi_annotations -%>
     private macro _register_unsafe_<%= vfunc.name %>_vfunc(impl_method_name)
       private def self._vfunc_unsafe_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
         <%-= vfunc_gi_annotations %>

--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -10,7 +10,7 @@
         raise GICrystal::ObjectCollectedError.new if %gc_collected || %instance.null?
 
         %retval = %instance.as(self).{{ impl_method_name.id }}(<% call_user_method(io) %>)
-        <%= convert_to_lib("%retval", vfunc.return_type, vfunc.caller_owns) %>
+        <%= convert_to_lib("%retval", vfunc.return_type, vfunc.caller_owns, vfunc.may_return_null?) %>
       end
 
     <%- if object.is_a?(InterfaceInfo) -%>

--- a/spec/libtest/test_iface_vfuncs.c
+++ b/spec/libtest/test_iface_vfuncs.c
@@ -55,6 +55,18 @@ gchar* test_iface_vfuncs_call_vfunc(TestIfaceVFuncs* self, const char* name) {
 
     iface->vfunc_bubble_up_with_args(self, 5);
     buffer = g_strdup("success");
+  } else if (!strcmp(name, "vfunc_return_nullable_string")) {
+    g_return_val_if_fail(iface->vfunc_return_nullable_string, NULL);
+
+    buffer = iface->vfunc_return_nullable_string(self);
+    if (!buffer)
+      buffer = "NULL";
+    buffer = g_strdup(buffer);
+  } else if (!strcmp(name, "vfunc_return_nullable_obj")) {
+    g_return_val_if_fail(iface->vfunc_return_nullable_obj, NULL);
+
+    TestSubject* obj = iface->vfunc_return_nullable_obj(self);
+    buffer = g_strdup(obj ? "Obj" : "NULL");
   } else
     g_warning("bad vfunc name: %s", name);
 

--- a/spec/libtest/test_iface_vfuncs.h
+++ b/spec/libtest/test_iface_vfuncs.h
@@ -3,6 +3,7 @@
 #include <glib-object.h>
 
 #include "test_regular_enum.h"
+#include "test_subject.h"
 
 G_BEGIN_DECLS
 
@@ -54,6 +55,20 @@ struct _TestIfaceVFuncsInterface {
    * @self: Self
    */
   TestRegularEnum (*vfunc_return_enum)(TestIfaceVFuncs* self);
+
+  /**
+   * TestIfaceVFuncsInterface::vfunc_return_nullable_string
+   * @self: Self.
+   * Returns: (nullable): A nullable GObject
+   */
+  char* (*vfunc_return_nullable_string)(TestIfaceVFuncs* self);
+
+  /**
+   * TestIfaceVFuncsInterface::vfunc_return_nullable_obj
+   * @self: Self.
+   * Returns: (type TestSubject) (transfer none) (nullable): A nullable GObject
+   */
+  TestSubject* (*vfunc_return_nullable_obj)(TestIfaceVFuncs* self);
 };
 
 /**

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -79,7 +79,7 @@ typedef void (*TestSubjectSimpleFunc)(TestSubject* subject, int number, gpointer
  *
  * Used to test callbacks with pointer parameters
  */
-typedef void (*TestSubjectCallbackWithPointer) (gpointer data, GObject* object, gboolean boolean);
+typedef void (*TestSubjectCallbackWithPointer)(gpointer data, GObject* object, gboolean boolean);
 
 /**
  * test_subject_new_from_whatever:

--- a/spec/vfunc_spec.cr
+++ b/spec/vfunc_spec.cr
@@ -9,6 +9,8 @@ private class IfaceVFuncImpl < GObject::Object
   getter string : String?
   getter obj : GObject::Object?
   property bool_return_value = false
+  property nullable_string_return_value : String?
+  property nullable_obj_return_value : Test::Subject?
 
   @[GObject::Virtual]
   def vfunc_basic(@int32, @float32, @float64, @string, @obj)
@@ -27,6 +29,16 @@ private class IfaceVFuncImpl < GObject::Object
   @[GObject::Virtual]
   def vfunc_return_enum
     Test::RegularEnum::Value2
+  end
+
+  @[GObject::Virtual]
+  def vfunc_return_nullable_string : String?
+    @nullable_string_return_value
+  end
+
+  @[GObject::Virtual]
+  def vfunc_return_nullable_obj : Test::Subject?
+    @nullable_obj_return_value
   end
 end
 
@@ -101,6 +113,28 @@ describe "GObject vfuncs" do
   it "can return an enum" do
     obj = IfaceVFuncImpl.new
     obj.call_vfunc("vfunc_return_enum").should eq("TEST_VALUE2")
+  end
+
+  it "can return nil on a String? return type restriction" do
+    obj = IfaceVFuncImpl.new
+    obj.call_vfunc("vfunc_return_nullable_string").should eq("NULL")
+  end
+
+  it "can return an String on a String? return type restriction" do
+    obj = IfaceVFuncImpl.new
+    obj.nullable_string_return_value = "hey"
+    obj.call_vfunc("vfunc_return_nullable_string").should eq("hey")
+  end
+
+  it "can return nil on a Object? return type restriction" do
+    obj = IfaceVFuncImpl.new
+    obj.call_vfunc("vfunc_return_nullable_string").should eq("NULL")
+  end
+
+  it "can return an object on a Object? return type restriction" do
+    obj = IfaceVFuncImpl.new
+    obj.nullable_obj_return_value = Test::Subject.new
+    obj.call_vfunc("vfunc_return_nullable_obj").should eq("Obj")
   end
 
   it "can chain vfuncs up" do

--- a/src/generator/callable_gen.cr
+++ b/src/generator/callable_gen.cr
@@ -1,0 +1,22 @@
+module Generator
+  abstract class CallableGen < Generator
+    abstract def callable : CallableInfo
+
+    def method_gi_annotations : String
+      args = callable.args
+      String.build do |io|
+        io << "# "
+        callable.to_s(io) << ": (" << callable.flags.to_s << ")\n"
+        args_gi_annotations(io, args)
+
+        io << "# Returns: (transfer " << callable.caller_owns.to_s.downcase
+        return_type = callable.return_type
+        io << ") (filename" if return_type.tag.filename?
+        io << ") (nullable" if callable.may_return_null?
+        io << ") "
+        type_info_gi_annotations(io, callable.return_type, args)
+        io << LF
+      end
+    end
+  end
+end

--- a/src/generator/helpers.cr
+++ b/src/generator/helpers.cr
@@ -140,11 +140,15 @@ module Generator::Helpers
     end
   end
 
-  def convert_to_lib(var : String, type : TypeInfo, _transfer : Transfer) : String
+  def convert_to_lib(var : String, type : TypeInfo, _transfer : Transfer, nullable : Bool) : String
     tag = type.tag
     case tag
     when .utf8?, .filename?
-      "#{var}.to_unsafe"
+      if nullable
+        "#{var}.nil? ? Pointer(UInt8).null : #{var}.to_unsafe"
+      else
+        "#{var}.to_unsafe"
+      end
     when .boolean?
       "#{var} ? 1 : 0"
     when .interface?
@@ -152,7 +156,11 @@ module Generator::Helpers
       if iface.is_a?(EnumInfo)
         "#{var}.#{tag_conversion_function(iface.storage_type)}"
       else
-        "#{var}.to_unsafe"
+        if nullable
+          "#{var}.nil? ? Pointer(Void).null : #{var}.to_unsafe"
+        else
+          "#{var}.to_unsafe"
+        end
       end
     else
       var

--- a/src/generator/method_gen.cr
+++ b/src/generator/method_gen.cr
@@ -1,7 +1,8 @@
 require "./arg_strategy"
+require "./callable_gen"
 
 module Generator
-  class MethodGen < Generator
+  class MethodGen < CallableGen
     include WrapperUtil
 
     alias MethodReturnType = TypeInfo | ArgInfo
@@ -28,6 +29,10 @@ module Generator
 
     def throws? : Bool
       @method.flags.throws?
+    end
+
+    def callable : CallableInfo
+      @method
     end
 
     private def method_identifier : String

--- a/src/generator/struct_gen.cr
+++ b/src/generator/struct_gen.cr
@@ -159,7 +159,7 @@ module Generator
         end
       else
         io << ".value = "
-        io << convert_to_lib("value", field_type, :none)
+        io << convert_to_lib("value", field_type, :none, false)
       end
       io << "\nvalue\n"
       io << "end\n"

--- a/src/generator/vfunc_gen.cr
+++ b/src/generator/vfunc_gen.cr
@@ -1,8 +1,9 @@
 require "./arg_strategy"
+require "./callable_gen"
 require "./box_helper"
 
 module Generator
-  class VFuncGen < Generator
+  class VFuncGen < CallableGen
     include BoxHelper
     include Helpers
 
@@ -31,6 +32,10 @@ module Generator
           io << to_identifier(arg_name) << '=' << "lib_" << arg_name << LF
         end
       end
+    end
+
+    def callable : CallableInfo
+      @vfunc
     end
 
     private def call_user_method(io)

--- a/src/gobject_introspection/callable_info.cr
+++ b/src/gobject_introspection/callable_info.cr
@@ -27,5 +27,9 @@ module GObjectIntrospection
     def caller_owns
       Transfer.from_value(LibGIRepository.g_callable_info_get_caller_owns(self))
     end
+
+    def to_s(io : IO)
+      io << (name? || "?")
+    end
   end
 end

--- a/src/gobject_introspection/function_info.cr
+++ b/src/gobject_introspection/function_info.cr
@@ -41,5 +41,9 @@ module GObjectIntrospection
     def flags
       Flags.from_value(LibGIRepository.g_function_info_get_flags(self))
     end
+
+    def to_s(io : IO)
+      io << symbol
+    end
   end
 end


### PR DESCRIPTION
I didn't fix https://github.com/hugopl/gi-crystal/issues/102 also in this branch just for lack of time to write tests, but it's very easy to fix, just a small change in `convert_to_lib` function.

This PR also add GI information to vfunc's to easy debugging.

Fix #103 