### PR TITLE
Annotate deprecated methods in generated bindings.

### DIFF
--- a/ecr/method.ecr
+++ b/ecr/method.ecr
@@ -1,4 +1,7 @@
 <% render_doc(object, method) -%>
+<% if method.deprecated? -%>
+@[Deprecated]
+<% end -%>
 def <%= method_identifier %>(<% render_args_declaration -%>) <%= method_return_type_declaration %>
   <%= method_gi_annotations %>
   <% if throws? -%>

--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -9,6 +9,16 @@ class SubjectChildStore
 end
 
 describe "GObject Binding" do
+  it "generate @[Deprecated] annotations on deprecated methods" do
+    deprecated_methods = [] of String
+    {% for method in Test::Subject.methods %}
+      {% if method.annotation(Deprecated) %}
+        deprecated_methods << {{ method.name.stringify }}
+      {% end %}
+    {% end %}
+    deprecated_methods.should eq(%w(deprecated_method))
+  end
+
   describe "reference counting" do
     it "accessible by ref_count method" do
       subject = Test::Subject.new(boolean: true)

--- a/spec/libtest/test_subject.c
+++ b/spec/libtest/test_subject.c
@@ -670,6 +670,9 @@ int test_subject_sum_array_of_4_ints(TestSubject* self, int* array) {
   return acc;
 }
 
+void test_subject_deprecated_method(TestSubject* self) {
+}
+
 GError* test_subject_return_g_error() {
   return g_error_new(G_FILE_ERROR, G_FILE_ERROR_FAILED, "whatever message");
 }

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -431,6 +431,15 @@ int test_subject_nullable_optimal_parameter(TestSubject* self, gchar** param);
 int test_subject_sum_array_of_4_ints(TestSubject* self, int* array);
 
 /**
+ * test_subject_deprecated_method:
+ *
+ * Used to test generation of @[Deprecated] annotations.
+ *
+ * Deprecated: This method is deprecated
+ */
+void test_subject_deprecated_method(TestSubject* self);
+
+/**
  * test_subject_return_g_error:
  * Returns: (transfer full): A GError
  *


### PR DESCRIPTION
GObjectIntrospection only have the deprecated flag... the reason exists only in the XML, so I just generate empty `@[Deprecated]` annotations.
