### PR TITLE
Check if object is null before increase the reference on transfer full parameters.

### DIFF
--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -33,6 +33,20 @@ describe "GObject Binding" do
       subject.ref_count.should eq(1)
       Test::Subject.transfer_full_param(subject)
       subject.ref_count.should eq(2)
+
+      # be nice and don't leak ref on tests
+      LibGObject.g_object_unref(subject)
+    end
+
+    it "increase object reference when passing it to a nullable transfer full parameter" do
+      subject = Test::Subject.new(boolean: true)
+      Test::Subject.nullable_transfer_full_param(nil)
+
+      subject.ref_count.should eq(1)
+      Test::Subject.nullable_transfer_full_param(subject)
+      subject.ref_count.should eq(2)
+      # be nice and don't leak ref on tests
+      LibGObject.g_object_unref(subject)
     end
 
     it "sink float references on constructors" do

--- a/spec/libtest/test_subject.c
+++ b/spec/libtest/test_subject.c
@@ -383,6 +383,9 @@ TestSubject* test_subject_may_return_null(TestSubject* self, gboolean return_nil
 void test_subject_transfer_full_param(GObject* subject) {
 }
 
+void test_subject_nullable_transfer_full_param(GObject* gobj) {
+}
+
 gchar* test_subject_concat_strings(TestSubject* self, int n, const gchar** strings) {
   if (n == 0 || strings == NULL)
     return g_strdup("");

--- a/spec/libtest/test_subject.h
+++ b/spec/libtest/test_subject.h
@@ -121,6 +121,12 @@ TestSubject* test_subject_may_return_null(TestSubject* self, gboolean return_nil
 void test_subject_transfer_full_param(GObject* subject);
 
 /**
+ * test_subject_nullable_transfer_full_param:
+ * @gobj: (transfer full) (nullable):
+ */
+void test_subject_nullable_transfer_full_param(GObject* gobj);
+
+/**
  * test_subject_concat_strings:
  * @n: number of strings to concat.
  * @strings: (array length=n) (element-type utf8) (nullable): a buffer

--- a/src/generator/arg_strategy.cr
+++ b/src/generator/arg_strategy.cr
@@ -329,7 +329,10 @@ module Generator
       arg = strategy.arg
       obj = arg.type_info.interface.as(ObjectInfo)
 
-      io << "LibGObject." << obj.ref_function << '(' << to_identifier(arg.name) << ")"
+      var = to_identifier(arg.name)
+
+      io << "LibGObject." << obj.ref_function << '(' << var << ")"
+      io << " if " << var if arg.nullable?
     end
 
     def generate_lib_implementation(io : IO, strategy : ArgStrategy) : Nil


### PR DESCRIPTION

Fix #119