### PR TITLE
Remove hardcoded calls to g_object_ref from generator.

### DIFF
--- a/ecr/method.ecr
+++ b/ecr/method.ecr
@@ -18,9 +18,6 @@ def <%= method_identifier %>(<% render_args_declaration -%>) <%= method_return_t
   <% end -%>
 
   # Return value handling
-  <% if method.constructor? && method.caller_owns.none? -%>
-    LibGObject.g_object_ref_sink(_retval)
-  <% end %>
   <%= method_return %>
 end
 

--- a/src/bindings/g_object/gi_crystal.cr
+++ b/src/bindings/g_object/gi_crystal.cr
@@ -15,4 +15,16 @@ module GICrystal
     LibGObject.g_param_spec_set_qdata(object, INSTANCE_QDATA_KEY, Pointer(Void).null)
     LibGObject.g_param_spec_unref(object)
   end
+
+  # Increase the `GObject::Object` reference.
+  @[AlwaysInline]
+  def ref(obj : GObject::Object) : Nil
+    LibGObject.g_object_ref(obj)
+  end
+
+  # Increase the `GObject::ParamSpec` reference.
+  @[AlwaysInline]
+  def ref(obj : GObject::ParamSpec) : Nil
+    LibGObject.g_param_spec_ref(obj)
+  end
 end

--- a/src/generator/arg_strategy.cr
+++ b/src/generator/arg_strategy.cr
@@ -32,13 +32,13 @@ module Generator
     def self.find_strategies(method : CallableInfo, direction : Direction) : Array(ArgStrategy)
       strategies = method.args.map { |arg| ArgStrategy.new(method, arg) }
       {% for plan_class in %w(CallbackArgPlan
+                             TransferFullArgPlan
                              ArrayLengthArgPlan
                              OutArgUsedInReturnPlan
                              NullableArrayPlan
                              ArrayArgPlan
                              CallerAllocatesPlan
                              HandmadeArgPlan
-                             TransferFullArgPlan
                              GErrorArgPlan
                              BuiltInTypeArgPlan) %}
       plan = {{ plan_class.id }}.new(strategies)
@@ -331,9 +331,7 @@ module Generator
       obj = arg.type_info.interface.as(RegisteredTypeInfo)
 
       var = to_identifier(arg.name)
-
-      io << "LibGObject." << obj.ref_function << '(' << var << ")"
-      io << " if " << var if arg.nullable?
+      io << "GICrystal.ref(" << var << ")\n"
     end
 
     def generate_lib_implementation(io : IO, strategy : ArgStrategy) : Nil

--- a/src/gi-crystal.cr
+++ b/src/gi-crystal.cr
@@ -56,6 +56,11 @@ module GICrystal
     value ? 1 : 0
   end
 
+  # This method must be implemented in bindings for all base types that have reference counting.
+  @[AlwaysInline]
+  def ref(null : Nil) : Nil
+  end
+
   # :nodoc:
   def transfer_null_ended_array(ptr : Pointer(Pointer(UInt8)), transfer : Transfer) : Array(String)
     res = Array(String).new

--- a/src/gobject_introspection/interface_info.cr
+++ b/src/gobject_introspection/interface_info.cr
@@ -41,13 +41,5 @@ module GObjectIntrospection
       ptr = LibGIRepository.g_interface_info_get_iface_struct(self)
       StructInfo.new(ptr) if ptr
     end
-
-    def unref_function : String
-      "g_object_unref"
-    end
-
-    def ref_function : String
-      "g_object_ref"
-    end
   end
 end

--- a/src/gobject_introspection/object_info.cr
+++ b/src/gobject_introspection/object_info.cr
@@ -21,20 +21,6 @@ module GObjectIntrospection
       ObjectInfo.new(ptr) if ptr
     end
 
-    def unref_function : String
-      func = LibGIRepository.g_object_info_get_unref_function(self)
-      func.null? ? "g_object_unref" : String.new(func)
-    end
-
-    def ref_function : String
-      func = LibGIRepository.g_object_info_get_ref_function(self)
-      return "g_object_ref_sink" if func.null?
-
-      ref_func = String.new(func)
-      # FIXME: g_param_spec_ref_sink seems bad or I'm doing something wrong.
-      ref_func == "g_param_spec_ref_sink" ? "g_param_spec_ref" : ref_func
-    end
-
     # Return true for fundamental types, like GParamSpec, GObject isn't considered
     # a fundamental type by introspection API.
     def fundamental? : Bool

--- a/src/gobject_introspection/registered_type_info.cr
+++ b/src/gobject_introspection/registered_type_info.cr
@@ -6,13 +6,5 @@ module GObjectIntrospection
     end
 
     abstract def methods : Array(FunctionInfo)
-
-    def unref_function : String
-      raise ArgumentError.new("ref/unref functions only exists for object/interface info.")
-    end
-
-    def ref_function : String
-      raise ArgumentError.new("ref/unref functions only exists for object/interface info.")
-    end
   end
 end


### PR DESCRIPTION
Bindings now need to implement `GICrystal.ref` for their types, GICrystal provides implementations for GObject and GParamSpec.