### PR TITLE
Fixes compilation with newer GObject libraries.

### DIFF
--- a/src/bindings/g_object/binding.yml
+++ b/src/bindings/g_object/binding.yml
@@ -256,6 +256,12 @@ types:
     - peek
     - peek_static
     - ref
+  TypeCValue:
+    ignore: true
+  TypeValueCollectFunc:
+    ignore: true
+  TypeValueLCopyFunc:
+    ignore: true
   TypeInterface:
     ignore_methods:
     - add_prerequisite


### PR DESCRIPTION
Tested with:

gobject-introspection 1.78
glibs2                2.78

Fix issue #124 