### PR TITLE
Implement interface cast.

### DIFF
--- a/ecr/interface.ecr
+++ b/ecr/interface.ecr
@@ -24,6 +24,17 @@ module <%= namespace_name %>
     <% render_vfuncs %>
     <% render_signals %>
 
+    # Cast a `GObject::Object` to `self`, throws a `TypeCastError` if the cast can't be made.
+    def self.cast(obj : GObject::Object) : self
+      cast?(obj) || raise TypeCastError.new("can't cast #{typeof(obj).name} to #{self}")
+    end
+
+    def self.cast?(obj : GObject::Object) : self?
+      if LibGObject.g_type_check_instance_is_a(obj, g_type) != 0
+        <%= abstract_interface_name(object, false) %>.new(obj.to_unsafe, :none)
+      end
+    end
+
     abstract def to_unsafe
   end
 

--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -124,6 +124,15 @@ describe "GObject Binding" do
       obj.as(Void*).should_not eq(subject.as(Void*))
     end
 
+    it "can be used on interfaces" do
+      ptr = LibGObject.g_object_new(Test::Subject.g_type, "float64", 0.5, Pointer(Void).null)
+      obj = GObject::Object.new(ptr, :full)
+      iface = Test::Iface.cast(obj)
+      iface.float64.should eq(0.5)
+      iface.ref_count.should eq(2)
+      iface.return_myself_as_interface.float64.should eq(0.5)
+    end
+
     it "can downcast objects" do
       child = Test::SubjectChild.new(string: "hey")
       gobj = child.me_as_gobject


### PR DESCRIPTION
This means we can now use the Editable interface to handle input of adwaita preferences dialogs.

Fixes #132