### PR TITLE
Fix setter of GObject properties when using nulable types.

### DIFF
--- a/ecr/property.ecr
+++ b/ecr/property.ecr
@@ -3,6 +3,8 @@
       <% if prop.type_info.array? -%>
         # handle array
         unsafe_value = value.to_a.map(&.to_unsafe).to_unsafe
+      <% elsif prop.type_info.object? -%>
+        unsafe_value = value.nil? ? Pointer(Void).null : value.to_unsafe
       <% else -%>
         unsafe_value = value
       <% end %>

--- a/spec/properties_spec.cr
+++ b/spec/properties_spec.cr
@@ -77,7 +77,7 @@ describe "GObject properties" do
     subject.gobj.object_id.should eq(value.object_id)
     value.ref_count.should eq(2)
 
-    subject.gobj = nil
+    subject.gobj = value.may_return_null(true)
     value.ref_count.should eq(1)
     subject.gobj.should eq(nil)
   end


### PR DESCRIPTION
Current tests were passing because Crystal compiler was smart enough to see that the types used would never be nil.