### PR TITLE
Merge gio.cr into gi-crystal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If you are looking for GTK4 bindings for Crystal, go to [GTK4](https://github.co
 I wrote this while studying GObject Introspection to contribute with [crystal-gobject](https://github.com/jhass/crystal-gobject)
 but at some point I decided to take a different approach on how to generate the bindings, so I started this.
 
+Besides the binding generator this shard provides bindings for GLib, GObject and Gio libraries.
+
 ## Installation
 
 You are probably looking for the [GTK4](https://github.com/hugopl/gtk4.cr) shard, not this one, since this shard is only
@@ -24,6 +26,7 @@ useful if you are creating a binding for a GObject based library.
    ```
 
 2. Run `shards install`
+3. Run `./bin/gi-crystal` to generate the bindings.
 
 ## Usage
 
@@ -33,6 +36,14 @@ files under the project directory and generate the bindings at `lib/gi-crystal/s
 The generator is compiled in a _post-install_ task and can be found at `bin/gi-crystal` after you run `shards install`.
 
 See https://github.com/hugopl/gtk4.cr for an example of how to use it.
+
+If you want to use just GLib, GObject or Gio bindings do:
+
+```Crystal
+require "gi-crystal/glib"    # Just GLib bindings
+require "gi-crystal/gobject" # GLib and GObject bindings
+require "gi-crystal/gio"     # GLib, GObject and Gio bindings
+```
 
 ## Memory Management ❤️‍🔥️
 

--- a/spec/gio_spec.cr
+++ b/spec/gio_spec.cr
@@ -1,0 +1,9 @@
+require "./spec_helper"
+
+describe Gio do
+  it "can register and fetch resources" do
+    resource = Gio.register_resource("spec/resource.xml", source_dir: "spec")
+    resource_bytes = resource.lookup_data("/spec/gio_spec.cr")
+    String.new(resource_bytes.data).should eq(File.read(__FILE__))
+  end
+end

--- a/spec/resource.xml
+++ b/spec/resource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/spec">
+    <file>gio_spec.cr</file>
+  </gresource>
+</gresources>

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,7 @@
 require "spec"
 
 require "../src/gi-crystal"
+require "../src/gio"
 require "../src/auto/test-1.0/test"
 
 # Used on basic signal tests or on something that would need a kind of global var to

--- a/src/bindings/gio/application.cr
+++ b/src/bindings/gio/application.cr
@@ -1,0 +1,16 @@
+module Gio
+  class Application
+    # Invoke `Application#run` with the process argc/argv.
+    #
+    # If no commandline handling is required you can invoke `Application#run(nil)`
+    def run : Int32
+      LibGio.g_application_run(self, ARGC_UNSAFE, ARGV_UNSAFE)
+    end
+
+    def run(argv : Enumerable(::String)?) : Int32
+      argv = [PROGRAM_NAME].concat(argv) if argv
+      # call generated method
+      previous_def(argv)
+    end
+  end
+end

--- a/src/bindings/gio/binding.yml
+++ b/src/bindings/gio/binding.yml
@@ -1,0 +1,147 @@
+namespace: Gio
+version: "2.0"
+require_after:
+- application.cr
+- resource.cr
+- list_model
+
+types:
+  AppLaunchContextPrivate:
+    ignore: true
+  ApplicationCommandLinePrivate:
+    ignore: true
+  ApplicationPrivate:
+    ignore: true
+  BufferedInputStreamPrivate:
+    ignore: true
+  BufferedOutputStreamPrivate:
+    ignore: true
+  CancellablePrivate:
+    ignore: true
+  ConverterInputStreamPrivate:
+    ignore: true
+  ConverterOutputStreamPrivate:
+    ignore: true
+  DataInputStreamPrivate:
+    ignore: true
+  DataOutputStreamPrivate:
+    ignore: true
+  DBusInterfaceSkeletonPrivate:
+    ignore: true
+  DBusObjectManagerClientPrivate:
+    ignore: true
+  DBusObjectManagerServerPrivate:
+    ignore: true
+  DBusObjectProxyPrivate:
+    ignore: true
+  DBusObjectSkeletonPrivate:
+    ignore: true
+  DBusProxyPrivate:
+    ignore: true
+  EmblemedIconPrivate:
+    ignore: true
+  FileEnumeratorPrivate:
+    ignore: true
+  FileInputStreamPrivate:
+    ignore: true
+  FileIOStreamPrivate:
+    ignore: true
+  FileMonitorPrivate:
+    ignore: true
+  FileOutputStreamPrivate:
+    ignore: true
+  Gio:
+    ignore_methods:
+    - unix_fd_list_peek_fds
+    - unix_fd_list_steal_fds
+    - unix_fd_message_steal_fds
+  InetAddressMaskPrivate:
+    ignore: true
+  InetAddressPrivate:
+    ignore: true
+  InetSocketAddressPrivate:
+    ignore: true
+  InputStreamPrivate:
+    ignore: true
+  IOStreamPrivate:
+    ignore: true
+  MemoryInputStreamPrivate:
+    ignore: true
+  MemoryOutputStreamPrivate:
+    ignore: true
+  MenuAttributeIterPrivate:
+    ignore: true
+  MenuLinkIterPrivate:
+    ignore: true
+  MenuModelPrivate:
+    ignore: true
+  MountOperationPrivate:
+    ignore: true
+  NativeSocketAddressPrivate:
+    ignore: true
+  NetworkAddressPrivate:
+    ignore: true
+  NetworkServicePrivate:
+    ignore: true
+  OutputStreamPrivate:
+    ignore: true
+  PermissionPrivate:
+    ignore: true
+  ProxyAddressEnumeratorPrivate:
+    ignore: true
+  ProxyAddressPrivate:
+    ignore: true
+  ResolverPrivate:
+    ignore: true
+  SettingsBackendPrivate:
+    ignore: true
+  SettingsPrivate:
+    ignore: true
+  SimpleActionGroupPrivate:
+    ignore: true
+  SimpleProxyResolverPrivate:
+    ignore: true
+  SocketClientPrivate:
+    ignore: true
+  SocketConnectionPrivate:
+    ignore: true
+  SocketControlMessagePrivate:
+    ignore: true
+  SocketListenerPrivate:
+    ignore: true
+  SocketPrivate:
+    ignore: true
+  SocketServicePrivate:
+    ignore: true
+  StaticResource:
+    ignore: true
+  TcpConnectionPrivate:
+    ignore: true
+  TcpWrapperConnectionPrivate:
+    ignore: true
+  ThreadedSocketServicePrivate:
+    ignore: true
+  TlsCertificatePrivate:
+    ignore: true
+  TlsConnectionPrivate:
+    ignore: true
+  TlsDatabasePrivate:
+    ignore: true
+  TlsInteractionPrivate:
+    ignore: true
+  TlsPasswordPrivate:
+    ignore: true
+  UnixConnectionPrivate:
+    ignore: true
+  UnixCredentialsMessagePrivate:
+    ignore: true
+  UnixFDListPrivate:
+    ignore: true
+  UnixFDMessagePrivate:
+    ignore: true
+  UnixInputStreamPrivate:
+    ignore: true
+  UnixOutputStreamPrivate:
+    ignore: true
+  UnixSocketAddressPrivate:
+    ignore: true

--- a/src/bindings/gio/list_model.cr
+++ b/src/bindings/gio/list_model.cr
@@ -1,0 +1,7 @@
+module Gio
+  module ListModel
+    def items_changed(position : Int, removed : Int, added : Int) : Nil
+      items_changed(position.to_u32, removed.to_u32, added.to_u32)
+    end
+  end
+end

--- a/src/bindings/gio/resource.cr
+++ b/src/bindings/gio/resource.cr
@@ -1,0 +1,44 @@
+module Gio
+  # Load the XML *resource_file* and register it, returning the `Gio::Resource`.
+  #
+  # When compiling in release mode this macro runs `glib-compile-resources` at compile time, so the XML is only needed at
+  # compile time. However when running in debug mode this macro runs `glib-compile-resources` at run time, so you don't
+  # need to recompile your program to e.g. see the changes in a UI file inside a GResource.
+  #
+  # By default the *resource_file* is read from the same directory where the compiler was invoked, to read it from
+  # a different directory use the *sourcedir* parameter.
+  #
+  # See `examples/resource.cr` for more info.
+  macro register_resource(resource_file, source_dir = ".")
+    begin
+      {% if flag?(:release) %}
+      {%
+        `glib-compile-resources --sourcedir #{source_dir} --target crystal-gio-resource.gresource #{resource_file}`
+        data = read_file("crystal-gio-resource.gresource")
+        # FIXME: This wont work on windows
+        `rm crystal-gio-resource.gresource`
+      %}
+      %resource_data = {{ data }}
+      {% else %}
+        `glib-compile-resources --sourcedir #{{{source_dir}}} --target crystal-gio-resource.gresource #{{{resource_file}}}`
+        %resource_data = File.read("crystal-gio-resource.gresource")
+        File.delete("crystal-gio-resource.gresource")
+      {% end %}
+      %gbytes = LibGLib.g_bytes_new_static(%resource_data, %resource_data.bytesize)
+      %error = Pointer(LibGLib::Error).null
+      %resource_ptr = LibGio.g_resource_new_from_data(%gbytes, pointerof(%error))
+      Gio.raise_gerror(%error) unless %error.null?
+
+      Gio::Resource.new(%resource_ptr, :full).tap do |%resource|
+        %resource._register
+      end
+    end
+  end
+
+  class Resource
+    # Same as `lookup_data(path, :none)`.
+    def lookup_data(path : ::String) : GLib::Bytes
+      lookup_data(path, :none)
+    end
+  end
+end

--- a/src/gio.cr
+++ b/src/gio.cr
@@ -1,0 +1,2 @@
+require "./gi-crystal"
+require "./auto/gio-2.0/gio"

--- a/src/glib.cr
+++ b/src/glib.cr
@@ -1,0 +1,2 @@
+require "./gi-crystal"
+require "./auto/g_lib-2.0/g_lib"

--- a/src/gobject.cr
+++ b/src/gobject.cr
@@ -1,0 +1,2 @@
+require "./gi-crystal"
+require "./auto/g_object-2.0/g_object"


### PR DESCRIPTION
Gio bindings were initially into GTK4 shard, then I removed it from there so people can re-use it on GTK3 bindings, however it fits better into GI-Crystal since Gio is distributed under the glib2 package in all distros.

That said, I'm archiving [Gio.cr](https://github.com/hugopl/gio.cr). Latest Gio.cr only work with gi-crystal v0.20.x
