### PR TITLE
Use ::Bytes on array of UInt8 parameters and return values.

### DIFF
--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -217,6 +217,14 @@ describe "GObject Binding" do
     end
   end
 
+  describe "array of uint8 parameters" do
+    it "are translated to Crystal ::Bytes" do
+      contents = File.read(File.join(__DIR__, "./resource.xml"))
+      mime = Gio.content_type_guess("file.ui", contents.to_slice)
+      mime.should eq("application/x-designer")
+    end
+  end
+
   describe "optional parameters" do
     it "are removed" do
       Test::Subject.no_optional_param.should eq(0)

--- a/spec/bytes_spec.cr
+++ b/spec/bytes_spec.cr
@@ -4,6 +4,6 @@ describe GLib::Bytes do
   it "data method return a Slice" do
     original_data = "hey ho lets go"
     g_bytes = GLib::Bytes.new(original_data.to_unsafe, original_data.bytesize)
-    String.new(g_bytes.data).should eq(original_data)
+    String.new(g_bytes.data.not_nil!).should eq(original_data)
   end
 end

--- a/spec/gio_spec.cr
+++ b/spec/gio_spec.cr
@@ -4,6 +4,6 @@ describe Gio do
   it "can register and fetch resources" do
     resource = Gio.register_resource("spec/resource.xml", source_dir: "spec")
     resource_bytes = resource.lookup_data("/spec/gio_spec.cr")
-    String.new(resource_bytes.data).should eq(File.read(__FILE__))
+    String.new(resource_bytes.data.not_nil!).should eq(File.read(__FILE__))
   end
 end

--- a/src/bindings/g_lib/bytes.cr
+++ b/src/bindings/g_lib/bytes.cr
@@ -3,11 +3,5 @@ module GLib
     def initialize(data : Pointer, size : Int32)
       @pointer = LibGLib.g_bytes_new(data, size)
     end
-
-    def data : Slice(UInt8)
-      data_size = 0_u64
-      data = LibGLib.g_bytes_get_data(@pointer, pointerof(data_size))
-      Slice.new(data.as(Pointer(UInt8)), data_size)
-    end
   end
 end

--- a/src/generator/arg_strategy.cr
+++ b/src/generator/arg_strategy.cr
@@ -117,7 +117,7 @@ module Generator
       arg = strategy.arg
       arg_type = strategy.arg_type
       io << to_identifier(strategies[arg_type.array_length].arg.name) << " = " << to_identifier(arg.name)
-      io << (arg.nullable? ? ".try(&.size) || 0" : ".size")
+      io << (arg.nullable? ? ".try(&.size) || 0" : ".size") << LF
     end
 
     def generate_c_to_crystal_implementation(io : IO, strategy : ArgStrategy) : Nil
@@ -202,7 +202,7 @@ module Generator
       arg_name = to_identifier(arg.name)
 
       generate_null_guard(io, arg_name, arg_type, nullable: arg.nullable?) do
-        if arg_type.array?
+        if arg_type.array? && !arg_type.param_type.tag.u_int8?
           generate_array_to_unsafe(io, arg_name, arg_type)
         else
           io << arg_name << ".to_unsafe"

--- a/src/generator/helpers.cr
+++ b/src/generator/helpers.cr
@@ -274,8 +274,12 @@ module Generator::Helpers
       return "Pointer(Void)" if iface.nil?
       to_crystal_type(iface, include_namespace)
     when .array?
-      t = to_crystal_type(type.param_type, include_namespace, is_arg: is_arg)
-      "Enumerable(#{t})"
+      if type.param_type.tag.u_int8?
+        "::Bytes"
+      else
+        t = to_crystal_type(type.param_type, include_namespace, is_arg: is_arg)
+        "Enumerable(#{t})"
+      end
     when tag.utf8?, .filename?, .g_list?, .gs_list?, .error?
       to_crystal_type(tag)
     else

--- a/src/gi-crystal.cr
+++ b/src/gi-crystal.cr
@@ -93,8 +93,8 @@ module GICrystal
   end
 
   # :nodoc:
-  def transfer_array(ptr : Pointer(UInt8), length : Int, transfer : Transfer) : Slice(UInt8)
-    slice = Slice(UInt8).new(ptr, length, read_only: true)
+  def transfer_array(ptr : Pointer(UInt8), length : Int, transfer : Transfer) : ::Bytes
+    slice = ::Bytes.new(ptr, length, read_only: true)
     if transfer.full?
       slice = slice.clone
       LibGLib.g_free(ptr)


### PR DESCRIPTION
This also speed up these methods by avoiding an unecessary array copy.

Fixes #137