### PR TITLE
Fixed directory path to be properly escaped

### DIFF
--- a/src/generator/main.cr
+++ b/src/generator/main.cr
@@ -6,7 +6,7 @@ require "./binding_config"
 require "./error"
 require "./module_gen"
 
-VERSION = {{ `shards version \"#{__DIR__}\"`.strip.stringify }}
+VERSION = {{ `shards version "#{__DIR__}"`.strip.stringify }}
 
 private def project_dir
   exe_path = Process.executable_path

--- a/src/generator/main.cr
+++ b/src/generator/main.cr
@@ -6,7 +6,7 @@ require "./binding_config"
 require "./error"
 require "./module_gen"
 
-VERSION = {{ `shards version #{__DIR__}`.strip.stringify }}
+VERSION = {{ `shards version \"#{__DIR__}\"`.strip.stringify }}
 
 private def project_dir
   exe_path = Process.executable_path


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/hugopl/gtk4.cr/issues/68), this should fix the error that occurs when installing the shard to a directory with a whitespace.