### PR TITLE
Revert "Do not raise GICrystal::ObjectCollectedError on unsafe versions of vfunc"

### DIFF
--- a/ecr/v_func.ecr
+++ b/ecr/v_func.ecr
@@ -31,7 +31,7 @@
       private def self._vfunc_unsafe_<%= vfunc.name %>(%this : Pointer(Void), <% generate_lib_args(io, vfunc) %>) : <%= return_type %>
         <%-= vfunc_gi_annotations %>
         %instance = LibGObject.g_object_get_qdata(%this, GICrystal::INSTANCE_QDATA_KEY)
-        return <%= type_info_default_value(vfunc.return_type) %> if %instance.null?
+        raise GICrystal::ObjectCollectedError.new if %instance.null?
 
         %instance.as(self).{{ impl_method_name.id }}(<% call_user_method_with_lib_args(io) %>)
       end


### PR DESCRIPTION
Reverts hugopl/gi-crystal#165

As always, it's not so simple.