### PR TITLE
Support MSYS2

### DIFF
--- a/ecr/module.ecr
+++ b/ecr/module.ecr
@@ -7,7 +7,7 @@ require "../<%= dep.module_dir %>/<%= dep.filename%>"
 require "./<%= @lib.filename %>"
 
 <% config.require_before.each do |inc| -%>
-require "<%= inc.relative_to("#{output_dir}/#{module_dir}") %>"
+require "<%= inc.relative_to("#{output_dir}/#{module_dir}").to_posix %>"
 <% end %>
 
 # Wrappers
@@ -110,5 +110,5 @@ module <%= namespace_name %>
 end
 
 <% config.require_after.each do |inc| -%>
-require "<%= inc.relative_to("#{output_dir}/#{module_dir}") %>"
+require "<%= inc.relative_to("#{output_dir}/#{module_dir}").to_posix %>"
 <% end %>

--- a/src/generator/lib_gen.cr
+++ b/src/generator/lib_gen.cr
@@ -6,7 +6,7 @@ module Generator
 
     private def libraries : Array(String)
       namespace.shared_libraries.map do |library|
-        library[/lib([^\/]+)\.(?:so|.+?\.dylib).*/, 1]
+        library[/lib([^\/]+)(?:\.so|-.+?\.dll|\..+?\.dylib).*/, 1]
       end
     end
 


### PR DESCRIPTION
* Recognizes shared libraries of the form `libgtk-4-1.dll` or `libgobject-2.0-0.dll`, as they appear under MSYS2. The revision portion and its leading hyphen are stripped to form the import library name.
* All Crystal relative require paths must use forward slashes, so `Path#to_posix` is added after calling `#relative_to`.

The GTK4 examples are confirmed to work on MSYS2's UCRT64 environment using `pacman -Sy mingw-w64-ucrt-x86_64-gtk4 mingw-w64-ucrt-x86_64-gobject-introspection`, and indeed, [the official website recommands MSYS2](https://www.gtk.org/docs/installations/windows).

This does not cover the MSVC toolchain, which would have required `dll:` arguments in the `@[Link]` annotations, and which might adopt different naming conventions.