### PR TITLE
Make final classes non-inheritable

### DIFF
--- a/ecr/object.ecr
+++ b/ecr/object.ecr
@@ -16,7 +16,7 @@ module <%= namespace_name %>
     <% end %>
 
     <% class_struct = object.class_struct -%>
-    <% if class_struct.nil? || object.fundamental? %>
+    <% if class_struct.nil? || object.fundamental? || object.final? %>
     macro inherited
       {{ raise "Cannot inherit from #{@type.superclass}" unless @type.annotation(GICrystal::GeneratedWrapper) }}
     end

--- a/src/gobject_introspection/lib_gobject_introspection.cr
+++ b/src/gobject_introspection/lib_gobject_introspection.cr
@@ -153,6 +153,7 @@ lib LibGIRepository
   fun g_object_info_get_class_struct(info : BaseInfo*) : BaseInfo*
   fun g_object_info_get_constant(info : BaseInfo*, n : Int32) : BaseInfo*
   fun g_object_info_get_field(info : BaseInfo*, n : Int32) : BaseInfo*
+  fun g_object_info_get_final(info : BaseInfo*) : LibC::Int
   fun g_object_info_get_fundamental(info : BaseInfo*) : LibC::Int
   fun g_object_info_get_get_value_function(info : BaseInfo*) : UInt8*
   fun g_object_info_get_interface(info : BaseInfo*, n : Int32) : BaseInfo*

--- a/src/gobject_introspection/object_info.cr
+++ b/src/gobject_introspection/object_info.cr
@@ -27,6 +27,10 @@ module GObjectIntrospection
       GICrystal.to_bool(LibGIRepository.g_object_info_get_fundamental(self))
     end
 
+    def final? : Bool
+      GICrystal.to_bool(LibGIRepository.g_object_info_get_final(self))
+    end
+
     def qdata_get_func : String
       # ⚠️ Ugly heuristic ahead
       unref_func = LibGIRepository.g_object_info_get_unref_function(self)


### PR DESCRIPTION
ref: https://github.com/GeopJr/libadwaita.cr/issues/6

If a class is final, it makes it non-inheritable, just like when it's fundamental.

However, there's an issue. The gtk gir files seem to be missing them(?). On my machine at least, there's no final attributes at all, so classes like Gtk::Picture won't be marked as sealed.

Before the final attribute was added, this seemed to be the way to distinguish them https://gitlab.gnome.org/GNOME/vala/-/issues/1036#note_1030537 but none of them apply to GtkPicture?