### PR TITLE
Do not generate bindings in src/auto on tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 /shard.lock
 /build/
 /spec/build/
-/src/auto/
+/src/generated/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ generator:
 	shards build --error-trace
 
 test-binding: libtest generator
-	GI_TYPELIB_PATH="./spec/build" LIBRARY_PATH="./spec/build" LD_LIBRARY_PATH="./spec/build" ./bin/gi-crystal spec/libtest_binding.yml -o src/auto --doc
+	GI_TYPELIB_PATH="./spec/build" LIBRARY_PATH="./spec/build" LD_LIBRARY_PATH="./spec/build" ./bin/gi-crystal spec/libtest_binding.yml -o src/generated --doc
 
 libtest:
 	+make --quiet -C ./spec/libtest

--- a/spec/docs_spec.cr
+++ b/spec/docs_spec.cr
@@ -14,7 +14,7 @@ describe "Docs conversion" do
       "# email_is_not_a_parameter: foo@example.com",
     }
 
-    test_subject = File.read("./src/auto/test-1.0/subject.cr")
+    test_subject = File.read("./src/generated/test-1.0/subject.cr")
 
     expected_results.each do |doc|
       test_subject.should contain(doc)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,7 +2,7 @@ require "spec"
 
 require "../src/gi-crystal"
 require "../src/gio"
-require "../src/auto/test-1.0/test"
+require "../src/generated/test-1.0/test"
 
 # Used on basic signal tests or on something that would need a kind of global var to
 # be sure something was called in another context.

--- a/src/gio.cr
+++ b/src/gio.cr
@@ -1,2 +1,18 @@
 require "./gi-crystal"
-require "./auto/gio-2.0/gio"
+
+# I recommend applications to add /lib/ to their repositories, this because new
+# versions of GTK libraries can break gi-crystal, so your source tarball won't
+# work anymore. Shipping /lib/ will include not only all crystal dependencies
+# sources but the generated GTK bindings.
+#
+# Then to update a shard dependency simpel do:
+#
+# rm -rf lib/
+# shards update
+# git add lib/
+# git commit -m"Crystal dependencies updated."
+{% if file_exists?("#{__DIR__}/generated/gio-2.0/gio.cr") %}
+  require "./generated/gio-2.0/gio"
+{% else %}
+  require "./auto/gio-2.0/gio"
+{% end %}


### PR DESCRIPTION
So applications can add their lib/ directory to the repositories to keep their code compiling with future binary compatible versions of GTK libraries.